### PR TITLE
Add agent-deck reference docs from upstream

### DIFF
--- a/plugins/agent-deck/skills/agent-deck/references/config-reference.md
+++ b/plugins/agent-deck/skills/agent-deck/references/config-reference.md
@@ -1,0 +1,251 @@
+# Configuration Reference
+
+All options for `~/.agent-deck/config.toml`.
+
+## Table of Contents
+
+- [Top-Level](#top-level)
+- [[claude] Section](#claude-section)
+- [[logs] Section](#logs-section)
+- [[updates] Section](#updates-section)
+- [[global_search] Section](#global_search-section)
+- [[mcp_pool] Section](#mcp_pool-section)
+- [[mcps.*] Section](#mcps-section)
+- [[tools.*] Section](#tools-section)
+
+## Top-Level
+
+```toml
+default_tool = "claude"   # Pre-selected tool when creating sessions
+```
+
+## [claude] Section
+
+Claude Code integration settings.
+
+```toml
+[claude]
+config_dir = "~/.claude-work"   # Path to Claude config directory
+dangerous_mode = true           # Enable --dangerously-skip-permissions
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `config_dir` | string | `~/.claude` | Claude config directory. Override with `CLAUDE_CONFIG_DIR` env. |
+| `dangerous_mode` | bool | `false` | Skip Claude permission dialogs. Required for automation. |
+
+## [logs] Section
+
+Session log file management.
+
+```toml
+[logs]
+max_size_mb = 10        # Max size before truncation
+max_lines = 10000       # Lines to keep when truncating
+remove_orphans = true   # Delete logs for removed sessions
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `max_size_mb` | int | `10` | Max log file size in MB. |
+| `max_lines` | int | `10000` | Lines to keep after truncation. |
+| `remove_orphans` | bool | `true` | Clean up logs for deleted sessions. |
+
+**Logs location:** `~/.agent-deck/logs/agentdeck_<session>_<id>.log`
+
+## [updates] Section
+
+Auto-update settings.
+
+```toml
+[updates]
+auto_update = false           # Auto-install updates
+check_enabled = true          # Check on startup
+check_interval_hours = 24     # Check frequency
+notify_in_cli = true          # Show in CLI commands
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `auto_update` | bool | `false` | Install updates without prompting. |
+| `check_enabled` | bool | `true` | Enable startup update checks. |
+| `check_interval_hours` | int | `24` | Hours between checks. |
+| `notify_in_cli` | bool | `true` | Show updates in CLI (not just TUI). |
+
+## [global_search] Section
+
+Search across all Claude conversations.
+
+```toml
+[global_search]
+enabled = true              # Enable global search
+tier = "auto"               # "auto", "instant", "balanced"
+memory_limit_mb = 100       # Max RAM for index
+recent_days = 90            # Limit to last N days (0 = all)
+index_rate_limit = 20       # Files/second for indexing
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Enable `G` key global search. |
+| `tier` | string | `"auto"` | Strategy: `instant` (fast, more RAM), `balanced` (LRU cache). |
+| `memory_limit_mb` | int | `100` | Max memory for balanced tier. |
+| `recent_days` | int | `90` | Only search recent conversations. |
+| `index_rate_limit` | int | `20` | Indexing speed (reduce for less CPU). |
+
+## [mcp_pool] Section
+
+Share MCP processes across sessions via Unix sockets.
+
+```toml
+[mcp_pool]
+enabled = false             # Enable socket pooling
+auto_start = true           # Start pool on launch
+pool_all = false            # Pool ALL MCPs
+exclude_mcps = []           # Exclude from pool_all
+fallback_to_stdio = true    # Fallback if socket fails
+show_pool_status = true     # Show 🔌 indicator
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `false` | Master switch for pooling. |
+| `pool_all` | bool | `false` | Pool all available MCPs. |
+| `exclude_mcps` | array | `[]` | MCPs to exclude when `pool_all=true`. |
+| `fallback_to_stdio` | bool | `true` | Use stdio if socket unavailable. |
+
+**Benefits:** 30 sessions x 5 MCPs = 150 processes -> 5 shared processes (90% memory savings).
+
+**Socket location:** `/tmp/agentdeck-mcp-{name}.sock`
+
+## [mcps.*] Section
+
+Define MCP servers. One section per MCP.
+
+### STDIO MCPs (Local)
+
+```toml
+[mcps.exa]
+command = "npx"
+args = ["-y", "exa-mcp-server"]
+env = { EXA_API_KEY = "your-key" }
+description = "Web search via Exa AI"
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `command` | string | Yes | Executable (npx, docker, node, python). |
+| `args` | array | No | Command arguments. |
+| `env` | map | No | Environment variables. |
+| `description` | string | No | Help text in MCP Manager. |
+
+### HTTP/SSE MCPs (Remote)
+
+```toml
+[mcps.remote]
+url = "https://api.example.com/mcp"
+transport = "http"   # or "sse"
+description = "Remote MCP server"
+```
+
+### Common MCP Examples
+
+```toml
+# Web search
+[mcps.exa]
+command = "npx"
+args = ["-y", "@anthropics/exa-mcp"]
+env = { EXA_API_KEY = "xxx" }
+
+# GitHub
+[mcps.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "ghp_xxx" }
+
+# Filesystem
+[mcps.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
+
+# Sequential thinking
+[mcps.thinking]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+
+# Playwright
+[mcps.playwright]
+command = "npx"
+args = ["-y", "@anthropics/playwright-mcp"]
+
+# Memory
+[mcps.memory]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-memory"]
+```
+
+## [tools.*] Section
+
+Define custom AI tools.
+
+```toml
+[tools.my-ai]
+command = "my-ai-assistant"
+icon = "🧠"
+busy_patterns = ["thinking...", "processing..."]
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `command` | string | Yes | Command to run. |
+| `icon` | string | No | Emoji for TUI (default: 🐚). |
+| `busy_patterns` | array | No | Strings indicating busy state. |
+
+**Built-in icons:** claude=🤖, gemini=✨, opencode=🌐, codex=💻, cursor=📝, shell=🐚
+
+## Complete Example
+
+```toml
+default_tool = "claude"
+
+[claude]
+config_dir = "~/.claude-work"
+dangerous_mode = true
+
+[logs]
+max_size_mb = 10
+max_lines = 10000
+remove_orphans = true
+
+[updates]
+check_enabled = true
+check_interval_hours = 24
+
+[global_search]
+enabled = true
+tier = "auto"
+recent_days = 90
+
+[mcp_pool]
+enabled = false
+
+[mcps.exa]
+command = "npx"
+args = ["-y", "exa-mcp-server"]
+env = { EXA_API_KEY = "your-key" }
+description = "Web search"
+
+[mcps.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "ghp_xxx" }
+description = "GitHub access"
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `AGENTDECK_PROFILE` | Override default profile |
+| `CLAUDE_CONFIG_DIR` | Override Claude config dir |
+| `AGENTDECK_DEBUG=1` | Enable debug logging |

--- a/plugins/agent-deck/skills/agent-deck/references/troubleshooting.md
+++ b/plugins/agent-deck/skills/agent-deck/references/troubleshooting.md
@@ -1,0 +1,229 @@
+# Troubleshooting Guide
+
+Common issues and solutions for agent-deck.
+
+## Quick Fixes
+
+| Issue | Solution |
+|-------|----------|
+| Session shows `✕` error | `agent-deck session start <name>` |
+| MCPs not loading | `agent-deck session restart <name>` |
+| CLI changes not in TUI | Press `Ctrl+R` to refresh |
+| Flag not working | Put flags BEFORE arguments |
+| Fork fails | Check session has valid Claude session ID |
+| Status stuck | Wait 2 seconds or press `u` to mark unread |
+
+## Common Issues
+
+### Flags Ignored
+
+**Problem:** Flags after positional arguments are silently ignored.
+
+```bash
+# WRONG - message not sent
+agent-deck session start my-project -m "Hello"
+
+# CORRECT
+agent-deck session start -m "Hello" my-project
+```
+
+### MCP Not Available
+
+1. Check if attached: `agent-deck mcp attached <session>`
+2. Restart session: `agent-deck session restart <session>`
+3. Verify in config: `agent-deck mcp list`
+
+### Session ID Not Detected
+
+Claude session ID needed for fork/resume. Check:
+
+```bash
+agent-deck session show <name> --json | jq '.claude_session_id'
+```
+
+If null, restart session and interact with Claude.
+
+### High CPU Usage
+
+**With many sessions:** Normal if batched updates. Check:
+```bash
+agent-deck status  # Should show ~0.5% CPU when idle
+```
+
+**With active session:** Normal (live preview updates).
+
+### Log Files Too Large
+
+Add to `~/.agent-deck/config.toml`:
+```toml
+[logs]
+max_size_mb = 1
+max_lines = 2000
+```
+
+### Global Search Not Working
+
+Check config:
+```toml
+[global_search]
+enabled = true
+```
+
+Also verify `~/.claude/projects/` exists and has content.
+
+## Debugging
+
+Enable debug logging:
+```bash
+AGENTDECK_DEBUG=1 agent-deck
+```
+
+Check session logs:
+```bash
+tail -100 ~/.agent-deck/logs/agentdeck_<session>_*.log
+```
+
+## Report a Bug
+
+If something isn't working, please create a GitHub issue with all relevant context.
+
+### Step 1: Gather Information
+
+Run these commands and save output:
+
+```bash
+# Version info
+agent-deck version
+
+# Current status
+agent-deck status --json
+
+# Session details (if session-related)
+agent-deck session show <session-name> --json
+
+# Config (sanitized - removes secrets)
+cat ~/.agent-deck/config.toml | grep -v "KEY\|TOKEN\|SECRET\|PASSWORD"
+
+# Recent logs (if error occurred)
+tail -100 ~/.agent-deck/logs/agentdeck_<session>_*.log 2>/dev/null
+
+# System info
+uname -a
+echo "tmux: $(tmux -V 2>/dev/null || echo 'not installed')"
+```
+
+### Step 2: Describe the Issue
+
+Prepare clear answers to:
+
+1. **What did you try?** (exact command or TUI action)
+2. **What happened?** (error message, unexpected behavior)
+3. **What did you expect?** (correct behavior)
+4. **Can you reproduce it?** (steps to trigger)
+
+### Step 3: Create GitHub Issue
+
+Go to: **https://github.com/asheshgoplani/agent-deck/issues/new**
+
+Use this template:
+
+```markdown
+## Description
+
+[Brief description of the issue]
+
+## Steps to Reproduce
+
+1. [First step]
+2. [Second step]
+3. [What happened]
+
+## Expected Behavior
+
+[What should have happened]
+
+## Environment
+
+- agent-deck version: [output of `agent-deck version`]
+- OS: [macOS/Linux/WSL]
+- tmux version: [output of `tmux -V`]
+
+## Debug Output
+
+<details>
+<summary>Status JSON</summary>
+
+```json
+[paste agent-deck status --json]
+```
+
+</details>
+
+<details>
+<summary>Config (sanitized)</summary>
+
+```toml
+[paste sanitized config]
+```
+
+</details>
+
+<details>
+<summary>Logs</summary>
+
+```
+[paste relevant log lines]
+```
+
+</details>
+```
+
+### Step 4: Follow Up
+
+- Check for responses on your issue
+- Test any suggested fixes
+- Update issue with results
+
+## Recovery
+
+### Session Metadata Lost
+
+Backups at:
+```bash
+~/.agent-deck/profiles/default/sessions.json.bak
+~/.agent-deck/profiles/default/sessions.json.bak.1
+~/.agent-deck/profiles/default/sessions.json.bak.2
+```
+
+Restore:
+```bash
+cp ~/.agent-deck/profiles/default/sessions.json.bak \
+   ~/.agent-deck/profiles/default/sessions.json
+```
+
+### tmux Sessions Lost
+
+Session logs preserved:
+```bash
+tail -500 ~/.agent-deck/logs/agentdeck_<session>_*.log
+```
+
+### Profile Corrupted
+
+Create fresh:
+```bash
+agent-deck profile create fresh
+agent-deck profile default fresh
+```
+
+## Critical Warnings
+
+**NEVER run these commands - they destroy ALL agent-deck sessions:**
+
+```bash
+# DO NOT RUN
+tmux kill-server
+tmux ls | grep agentdeck | xargs tmux kill-session
+```
+
+**Recovery impossible** - metadata backups exist but tmux sessions are gone.

--- a/plugins/agent-deck/skills/agent-deck/references/tui-reference.md
+++ b/plugins/agent-deck/skills/agent-deck/references/tui-reference.md
@@ -1,0 +1,186 @@
+# TUI Reference
+
+Complete reference for agent-deck Terminal UI features.
+
+## Keyboard Shortcuts
+
+### Navigation
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Move down |
+| `k` / `↑` | Move up |
+| `h` / `←` | Collapse group / go to parent |
+| `l` / `→` / `Tab` | Toggle expand/collapse group |
+| `1-9` | Jump to Nth root group |
+
+### Session Actions
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Attach to session OR toggle group |
+| `n` | New session (inherits current group) |
+| `r` | Rename session or group |
+| `R` | Restart session (reloads MCPs) |
+| `K` / `J` | Move item up/down in order |
+| `m` | Move session to different group |
+| `M` | Open MCP Manager (Claude/Gemini) |
+| `d` | Delete session or group |
+| `u` | Mark unread (idle -> waiting) |
+| `f` | Quick fork (Claude only) |
+| `F` | Fork with options (Claude only) |
+
+### Group Actions
+
+| Key | Action |
+|-----|--------|
+| `g` | Create group (subgroup if on group) |
+| `e` | Rename group (alias for `r`) |
+
+### Search & Filter
+
+| Key | Action |
+|-----|--------|
+| `/` | Local search (fuzzy) |
+| `G` | Global search (all Claude conversations) |
+| `Tab` | Switch between local/global search |
+| `0` | Clear filter (show all) |
+| `!` | Filter: running only (toggle) |
+| `@` | Filter: waiting only (toggle) |
+| `#` | Filter: idle only (toggle) |
+| `$` | Filter: error only (toggle) |
+
+### Global
+
+| Key | Action |
+|-----|--------|
+| `?` | Help overlay |
+| `i` | Import existing tmux sessions |
+| `Ctrl+R` | Manual refresh |
+| `Ctrl+Q` | Detach (keep tmux running) |
+| `q` / `Ctrl+C` | Quit |
+
+## Status Indicators
+
+| Symbol | Status | Color | Meaning |
+|--------|--------|-------|---------|
+| `●` | Running | Green | Active, content changed in last 2s |
+| `◐` | Waiting | Yellow | Stopped, unacknowledged |
+| `○` | Idle | Gray | Stopped, acknowledged |
+| `✕` | Error | Red | tmux session doesn't exist |
+| `⟳` | Starting | Yellow | Session launching |
+
+## Dialogs
+
+### New Session (`n`)
+
+**Fields:**
+- Session name (required)
+- Project path (required, supports `~/`)
+- Command (claude/gemini/opencode/codex/custom)
+- Parent group (auto-selected)
+
+**Controls:** `Tab` move fields | `Enter` create | `Esc` cancel
+
+### MCP Manager (`M`)
+
+**Layout:**
+- Two columns: Attached | Available
+- Two scopes: LOCAL | GLOBAL
+
+**Controls:**
+- `Tab` - Switch scope
+- `←/→` - Switch columns
+- `↑/↓` - Navigate
+- `Space` - Toggle MCP
+- `Enter` - Apply changes
+- `Esc` - Cancel
+
+**Indicators:**
+- `(l)` LOCAL scope
+- `(g)` GLOBAL scope
+- `(p)` PROJECT scope
+- `🔌` MCP is pooled
+- `⟳` Pending restart
+
+### Fork Dialog (`F`)
+
+**Fields:**
+- Session title (pre-filled)
+- Group (auto-selected)
+
+**Controls:** `Enter` fork | `Esc` cancel
+
+### Delete Confirmation (`d`)
+
+**For sessions:** Warning about tmux kill, process termination
+
+**For groups:** Sessions move to default (not deleted)
+
+**Controls:** `y` confirm | `n`/`Esc` cancel
+
+## Search
+
+### Local Search (`/`)
+
+- Fuzzy search session titles and groups
+- Max 10 results
+- `↑/↓` or `Ctrl+K/J` navigate
+- `Enter` select | `Tab` switch to global | `Esc` close
+
+### Global Search (`G`)
+
+- Full content search across `~/.claude/projects/`
+- Regex + fuzzy matching
+- Recency ranking
+- Split view: results + preview
+- `[/]` scroll preview
+- `Enter` create/jump to session
+
+**Config:**
+```toml
+[global_search]
+enabled = true
+recent_days = 30
+```
+
+## Preview Pane
+
+- Shows last ~500 lines of session's tmux pane
+- Auto-updates every 2 seconds
+- Launch animation: 6-15s for Claude/Gemini
+
+## Layout
+
+- **< 50 cols:** List only
+- **50-79 cols:** Stacked (list above preview)
+- **80+ cols:** Side-by-side (default)
+
+## Tool Icons
+
+| Tool | Icon | Color |
+|------|------|-------|
+| Claude | 🤖 | Orange |
+| Gemini | ✨ | Purple |
+| OpenCode | 🌐 | Cyan |
+| Codex | 💻 | Cyan |
+| Cursor | 📝 | Blue |
+| Shell | 🐚 | Default |
+
+## Color Scheme (Tokyo Night)
+
+| Element | Color |
+|---------|-------|
+| Accent (selection) | #7aa2f7 |
+| Running | #9ece6a |
+| Waiting | #e0af68 |
+| Error | #f7768e |
+| Groups | #7dcfff |
+| Background | #1a1b26 |
+| Surface | #24283b |
+
+## Hidden Features
+
+- **`Ctrl+K/J`:** Vim-style navigation in search
+- **Numbers 1-9:** Jump to root groups instantly
+- **Status filters are toggles:** Press again to turn off


### PR DESCRIPTION
Added from asheshgoplani/agent-deck:
- tui-reference.md (TUI navigation, keyboard shortcuts, status indicators)
- troubleshooting.md (quick fixes, debugging, recovery)
- config-reference.md (full config.toml reference, MCP pool)