### PR TITLE
Upgrade softprops/action-gh-release to v2

### DIFF
--- a/.github/workflows/release-guardian.yml
+++ b/.github/workflows/release-guardian.yml
@@ -64,7 +64,7 @@ jobs:
         run: ls -R artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: Security Guardian ${{ github.ref_name }}
           body: |


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow to use the latest version of the `softprops/action-gh-release` action, upgrading from v1 to v2.

## Changes
- Bumped `softprops/action-gh-release` action from v1 to v2 in the release-guardian workflow

## Details
This upgrade brings the release workflow in line with the latest version of the action, which may include bug fixes, performance improvements, and new features. The action is used to create GitHub releases with the built artifacts during the release process.

https://claude.ai/code/session_01Xz2zXjtsEpF9WjuQ4E1hom