### PR TITLE
feat(scrapedo): add auto-trigger conditions to skill description

### DIFF
--- a/plugins/scrapedo-web-scraper/skills/scrapedo-web-scraper/SKILL.md
+++ b/plugins/scrapedo-web-scraper/skills/scrapedo-web-scraper/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: scrapedo-web-scraper
-description: Веб-скрапинг через Scrape.do. Используй, если не получается посмотреть какой-то сайт (URL).
+description: |
+  Веб-скрапинг через Scrape.do. Обходит блокировки и CAPTCHA.
+  АВТОМАТИЧЕСКИ используй при ошибках WebFetch: 403, 401, 429,
+  timeout, access denied, Cloudflare block.
 ---
 
 # Scrape.do Web Scraper


### PR DESCRIPTION
## Summary
- Updated scrape.do skill frontmatter with specific auto-trigger conditions
- Description now lists HTTP errors (403, 401, 429), timeout, access denied, and Cloudflare block
- Removed generic trigger, kept description compact (3 lines)

## Test plan
- [ ] Verify skill is auto-triggered on WebFetch 403/401/429 errors
- [ ] Verify skill description renders correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)