### PR TITLE
fix(fal-ai-image): handle optional spaces in JSON parsing

### DIFF
--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/edit.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/edit.sh
@@ -76,8 +76,8 @@ SUBMIT_RESPONSE=$(curl -s -X POST "$API_BASE" \
     -H "Content-Type: application/json" \
     -d "$JSON_PAYLOAD")
 
-# Extract request_id via grep
-REQUEST_ID=$(echo "$SUBMIT_RESPONSE" | grep -o '"request_id":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract request_id via grep (handles optional space after colon)
+REQUEST_ID=$(echo "$SUBMIT_RESPONSE" | grep -oE '"request_id":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 
 if [[ -z "$REQUEST_ID" ]]; then
     echo "Error: Failed to submit request"
@@ -96,7 +96,7 @@ while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
     STATUS_RESPONSE=$(curl -s "$API_BASE/requests/$REQUEST_ID/status" \
         -H "Authorization: Key $FAL_KEY")
 
-    STATUS=$(echo "$STATUS_RESPONSE" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+    STATUS=$(echo "$STATUS_RESPONSE" | grep -oE '"status":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 
     case "$STATUS" in
         COMPLETED)
@@ -136,8 +136,8 @@ if [[ -n "$OUTPUT_DIR" ]]; then
     mkdir -p "$OUTPUT_DIR"
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
-    # Extract URLs via grep and download
-    URLS=$(echo "$RESULT" | grep -o '"url":"[^"]*"' | cut -d'"' -f4)
+    # Extract URLs via grep and download (handles optional space after colon)
+    URLS=$(echo "$RESULT" | grep -oE '"url":[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
     INDEX=0
 
     echo "Downloading images..."

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/generate.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/generate.sh
@@ -69,8 +69,8 @@ SUBMIT_RESPONSE=$(curl -s -X POST "$API_BASE" \
     -H "Content-Type: application/json" \
     -d "$JSON_PAYLOAD")
 
-# Extract request_id via grep
-REQUEST_ID=$(echo "$SUBMIT_RESPONSE" | grep -o '"request_id":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Extract request_id via grep (handles optional space after colon)
+REQUEST_ID=$(echo "$SUBMIT_RESPONSE" | grep -oE '"request_id":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 
 if [[ -z "$REQUEST_ID" ]]; then
     echo "Error: Failed to submit request"
@@ -89,7 +89,7 @@ while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
     STATUS_RESPONSE=$(curl -s "$API_BASE/requests/$REQUEST_ID/status" \
         -H "Authorization: Key $FAL_KEY")
 
-    STATUS=$(echo "$STATUS_RESPONSE" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+    STATUS=$(echo "$STATUS_RESPONSE" | grep -oE '"status":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 
     case "$STATUS" in
         COMPLETED)
@@ -129,8 +129,8 @@ if [[ -n "$OUTPUT_DIR" ]]; then
     mkdir -p "$OUTPUT_DIR"
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
-    # Extract URLs via grep and download
-    URLS=$(echo "$RESULT" | grep -o '"url":"[^"]*"' | cut -d'"' -f4)
+    # Extract URLs via grep and download (handles optional space after colon)
+    URLS=$(echo "$RESULT" | grep -oE '"url":[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
     INDEX=0
 
     echo "Downloading images..."

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/upload.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/upload.sh
@@ -64,8 +64,8 @@ INITIATE_RESPONSE=$(curl -s -X POST "https://rest.alpha.fal.ai/storage/upload/in
     -H "Content-Type: application/json" \
     -d "{\"file_name\": \"$FILENAME\", \"content_type\": \"$MIME_TYPE\"}")
 
-UPLOAD_URL=$(echo "$INITIATE_RESPONSE" | grep -o '"upload_url":"[^"]*"' | head -1 | cut -d'"' -f4)
-FILE_URL=$(echo "$INITIATE_RESPONSE" | grep -o '"file_url":"[^"]*"' | head -1 | cut -d'"' -f4)
+UPLOAD_URL=$(echo "$INITIATE_RESPONSE" | grep -oE '"upload_url":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+FILE_URL=$(echo "$INITIATE_RESPONSE" | grep -oE '"file_url":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 
 if [[ -z "$UPLOAD_URL" || -z "$FILE_URL" ]]; then
     echo "Error: Failed to get upload URL" >&2


### PR DESCRIPTION
## Summary
- Fix JSON parsing in fal.ai scripts to handle both compact (`"key":"value"`) and formatted (`"key": "value"`) API responses
- Update grep patterns in `generate.sh`, `edit.sh`, and `upload.sh` using `grep -oE` with `[[:space:]]*` and `sed` extraction
- Prevents silent failures when fal.ai API returns formatted JSON with spaces after colons

## Test plan
- [ ] Run `generate.sh` with a test prompt and verify `request_id` is extracted
- [ ] Run `edit.sh` with reference images and verify `request_id` extraction
- [ ] Run `upload.sh` with a local file and verify `upload_url`/`file_url` extraction
- [ ] Verify fallback to base64 in `upload.sh` still works when extraction fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)