### PR TITLE
fix(codex-review): positional session_id for codex exec resume

### DIFF
--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -260,7 +260,7 @@ Instructions:
         --model "$CODEX_MODEL" \
         -c "model_reasoning_effort=\"$CODEX_REASONING_EFFORT\"" \
         $(build_yolo_flag) \
-        resume --session "$SESSION_ID" \
+        resume "$SESSION_ID" \
         "$codex_prompt" 2>&1) || {
         local exit_code=$?
         echo "ERROR: Codex exec failed (exit $exit_code)." >&2


### PR DESCRIPTION
## Summary

- Fix: `codex exec resume --session "$ID"` → `codex exec resume "$ID"`
- `codex exec resume` expects SESSION_ID as positional arg, not `--session` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)