### PR TITLE
fix(codex-review): macOS bash 3.2 compatibility

### DIFF
--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -83,7 +83,7 @@ save_note() {
     local content="$3"
     local note_file="$STATE_DIR/notes/${phase}-review-${iteration}.md"
     {
-        echo "# ${phase^} Review #${iteration}"
+        echo "# $(echo "$phase" | awk '{print toupper(substr($0,1,1)) substr($0,2)}') Review #${iteration}"
         echo "Date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
         echo ""
         echo "$content"


### PR DESCRIPTION
## Summary

- Replace `${phase^}` (bash 4+ capitalize) with `awk toupper()` for macOS compatibility
- macOS ships bash 3.2 which doesn't support case modification operators

🤖 Generated with [Claude Code](https://claude.com/claude-code)