### PR TITLE
fix: register fal-ai-image and yandex-wordstat in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,6 +42,18 @@
       "description": "Cross-agent review workflow: Claude implements, Codex reviews",
       "source": "./plugins/codex-review",
       "category": "development"
+    },
+    {
+      "name": "fal-ai-image",
+      "description": "Generate images using fal.ai nano-banana model",
+      "source": "./plugins/fal-ai-image",
+      "category": "productivity"
+    },
+    {
+      "name": "yandex-wordstat",
+      "description": "Анализ поискового спроса через Yandex Wordstat API",
+      "source": "./plugins/yandex-wordstat",
+      "category": "productivity"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 /plugin install ssh-remote-connection
 /plugin install yandex-wordstat
 /plugin install codex-review
+/plugin install fal-ai-image
 ```
 
 ### Ручная установка (без маркетплейса)
@@ -175,6 +176,26 @@ SSH подключение к удалённым серверам с agent forwa
 
 ---
 
+### [fal-ai-image](plugins/fal-ai-image/skills/fal-ai-image)
+
+Генерация изображений через fal.ai nano-banana-pro (Gemini 3 Pro Image).
+
+- Генерация из текстового промпта (text-to-image)
+- Редактирование с референсными изображениями (image-to-image)
+- Поддержка разрешений 1K / 2K / 4K
+
+**Триггеры (RU):**
+- "сгенерируй изображение"
+- "нарисуй картинку"
+- "создай инфографику"
+
+**Триггеры (EN):**
+- "generate image"
+- "create infographic"
+- "draw a picture"
+
+---
+
 ## Структура репозитория
 
 ```
@@ -188,7 +209,8 @@ polyakov-claude-skills/
 │   ├── genome-analizer/      # Плагин для анализа генома
 │   ├── ssh-remote-connection/# Плагин для SSH
 │   ├── yandex-wordstat/      # Плагин для Wordstat API
-│   └── codex-review/         # Плагин для кросс-агентного ревью
+│   ├── codex-review/         # Плагин для кросс-агентного ревью
+│   └── fal-ai-image/         # Плагин для генерации изображений
 └── README.md
 ```
 


### PR DESCRIPTION
## Summary
- Added `fal-ai-image` and `yandex-wordstat` to `.claude-plugin/marketplace.json` (6 → 8 plugins)
- Added `fal-ai-image` documentation section, install command, and directory tree entry to README.md

## Test plan
- [x] `marketplace.json` is valid JSON with 8 plugins
- [x] All plugin `source` paths exist on disk
- [ ] Verify `fal-ai-image` is discoverable via `/plugin install fal-ai-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)