### PR TITLE
fix: correct plugin.json manifests for fal-ai-image and yandex-wordstat

### DIFF
--- a/plugins/fal-ai-image/.claude-plugin/plugin.json
+++ b/plugins/fal-ai-image/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "fal-ai-image",
   "version": "1.0.0",
   "description": "Generate images using fal.ai nano-banana model",
-  "author": "polyakov",
-  "skills": ["fal-ai-image"]
+  "author": {
+    "name": "Polyakov"
+  }
 }

--- a/plugins/yandex-wordstat/.claude-plugin/plugin.json
+++ b/plugins/yandex-wordstat/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "yandex-wordstat",
   "version": "1.0.0",
   "description": "Analyze search demand via Yandex Wordstat API",
-  "author": "polyakov",
-  "skills": ["yandex-wordstat"]
+  "author": {
+    "name": "Polyakov"
+  }
 }


### PR DESCRIPTION
## Summary
- Fixed `author` field: changed from string `"polyakov"` to object `{"name": "Polyakov"}` per manifest schema
- Removed invalid `skills` field from both plugin manifests
- Affects: `fal-ai-image`, `yandex-wordstat`

## Test plan
- [ ] `plugin install fal-ai-image` succeeds without validation errors
- [ ] `plugin install yandex-wordstat` succeeds without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)