### PR TITLE
docs: add CLAUDE.md with plugin manifest rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,23 @@
+# Правила проекта polyakov-claude-skills
+
+## plugin.json — формат манифеста
+
+При создании/редактировании `.claude-plugin/plugin.json`:
+
+- **`author`** — ОБЯЗАТЕЛЬНО объект: `{"name": "Polyakov"}`. Строка вызывает ошибку валидации.
+- **`skills`** — НЕ валидное поле. Не добавлять. Скиллы обнаруживаются автоматически из `skills/` директории.
+- Эталонный формат:
+  ```json
+  {
+    "name": "plugin-name",
+    "version": "1.0.0",
+    "description": "...",
+    "author": {
+      "name": "Polyakov"
+    }
+  }
+  ```
+
+## marketplace.json
+
+- При добавлении нового плагина — обязательно добавить запись в `.claude-plugin/marketplace.json` → `plugins[]`, иначе плагин не будет виден через `/plugin install`.


### PR DESCRIPTION
## Summary
- Added `.claude/CLAUDE.md` with project rules to prevent recurring plugin manifest errors
- Documents correct `plugin.json` schema (`author` must be object, no `skills` field)
- Documents `marketplace.json` registration requirement

## Context
These rules come from debugging installation failures in #34 / #35 — `author` was a string instead of an object, and `skills` was an invalid field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)