### PR TITLE
docs(fal-ai-image): add common mistakes and model capabilities

### DIFF
--- a/plugins/fal-ai-image/skills/fal-ai-image/SKILL.md
+++ b/plugins/fal-ai-image/skills/fal-ai-image/SKILL.md
@@ -1,12 +1,36 @@
 ---
 name: fal-ai-image
-description: Generate images using fal.ai nano-banana-pro model
+description: "Generate/edit images via fal.ai nano-banana-pro. Supports reference images (Edit mode) and text rendering in any language including Cyrillic. ALWAYS read SKILL.md before first use."
 ---
 
 # fal-ai-image
 
 Generate images via fal.ai nano-banana-pro (Gemini 3 Pro Image).
 Best for: infographics, text rendering, complex compositions.
+
+## STOP — Read Before Acting
+
+- **DO NOT** use Pillow, ImageMagick, or any post-processing for text/logo overlay — this model renders text natively, including Cyrillic and CJK
+- **DO NOT** use Generate mode when user provides reference images — use **Edit mode**
+- **DO NOT** launch general-purpose subagents — use `Task` with `subagent_type: "Bash"` and `model: "haiku"`
+- **DO NOT** skip uploading local files — run `upload.sh` first to get URLs for `edit.sh`
+- **DO NOT** guess script parameters — check the tables below
+
+## Quick Start Decision
+
+```
+User gave reference images?  → Edit mode  (upload.sh → edit.sh)
+User wants text-only gen?    → Generate mode (generate.sh)
+Multiple images needed?      → Parallel Bash/haiku subagents
+```
+
+## Model Capabilities
+
+- Excellent text rendering (Latin, Cyrillic, CJK) — no post-processing needed
+- Composes logos, product photos, and text into banners in a single pass
+- Understands layout instructions ("left side text, right side product photo")
+- Handles complex infographics, charts, and diagrams
+- Edit mode blends reference images naturally with prompt guidance
 
 ## Config
 


### PR DESCRIPTION
## Summary
- Expanded SKILL.md frontmatter description with Edit mode and text rendering info
- Added "STOP — Read Before Acting" section with 5 common mistakes to avoid
- Added "Quick Start Decision" tree for fast mode selection
- Added "Model Capabilities" section highlighting native text rendering (Cyrillic, CJK)

## Context
Based on real usage session where agent made avoidable errors:
1. Used Pillow for text overlay instead of trusting the model
2. Used Generate mode instead of Edit with reference images
3. Launched general-purpose subagents instead of Bash + haiku

## Test plan
- [ ] Verify SKILL.md renders correctly in markdown preview
- [ ] Verify frontmatter is valid YAML
- [ ] Test that skill still loads correctly via /fal-ai-image

Generated with [Claude Code](https://claude.com/claude-code)