### PR TITLE
fix(fal-ai-image): POSIX sh compatibility for cloud sandboxes

### DIFF
--- a/plugins/fal-ai-image/skills/fal-ai-image/SKILL.md
+++ b/plugins/fal-ai-image/skills/fal-ai-image/SKILL.md
@@ -32,6 +32,11 @@ Multiple images needed?      → Parallel Bash/haiku subagents
 - Handles complex infographics, charts, and diagrams
 - Edit mode blends reference images naturally with prompt guidance
 
+## Compatibility
+
+Scripts are POSIX sh compatible — work in cloud sandboxes (`/bin/sh`) and locally (`bash`).
+No bashisms: `[[ ]]`, `${BASH_SOURCE}`, `source` etc. are NOT used.
+
 ## Config
 
 Requires `FAL_KEY` in `config/.env` or environment.
@@ -96,7 +101,7 @@ Script: `scripts/edit.sh`
 
 ### generate.sh
 ```bash
-bash scripts/generate.sh \
+sh scripts/generate.sh \
   --prompt "infographic about coffee brewing" \
   --aspect-ratio "9:16" \
   --resolution "1K" \
@@ -116,7 +121,7 @@ bash scripts/generate.sh \
 
 ### edit.sh
 ```bash
-bash scripts/edit.sh \
+sh scripts/edit.sh \
   --prompt "combine these into a collage" \
   --image-urls "https://example.com/img1.png,https://example.com/img2.png" \
   --aspect-ratio "16:9" \
@@ -137,10 +142,10 @@ bash scripts/edit.sh \
 ### upload.sh (for local files)
 ```bash
 # Get URL for local file
-URL=$(bash scripts/upload.sh --file /path/to/image.png)
+URL=$(sh scripts/upload.sh --file /path/to/image.png)
 
 # Or get base64 data URI (for small files)
-URI=$(bash scripts/upload.sh --file /path/to/image.png --base64)
+URI=$(sh scripts/upload.sh --file /path/to/image.png --base64)
 ```
 
 ## Parallel Generation

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/edit.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/edit.sh
@@ -1,20 +1,21 @@
-#!/bin/bash
+#!/bin/sh
 # Generate images with reference images using fal.ai nano-banana-pro/edit
+# POSIX sh compatible — works in cloud sandboxes and locally
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/../config/.env"
 API_BASE="https://queue.fal.run/fal-ai/nano-banana-pro/edit"
 STATUS_BASE="https://queue.fal.run/fal-ai/nano-banana-pro"
 
 # Load config
-if [[ -f "$CONFIG_FILE" ]]; then
+if [ -f "$CONFIG_FILE" ]; then
     # shellcheck disable=SC1090
-    source "$CONFIG_FILE"
+    . "$CONFIG_FILE"
 fi
 
-if [[ -z "$FAL_KEY" ]]; then
+if [ -z "$FAL_KEY" ]; then
     echo "Error: FAL_KEY not found. Set in config/.env or environment."
     exit 1
 fi
@@ -30,7 +31,7 @@ OUTPUT_DIR=""
 FILENAME="edited"
 
 # Parse args
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case $1 in
         --prompt|-p) PROMPT="$2"; shift 2 ;;
         --image-urls|-i) IMAGE_URLS="$2"; shift 2 ;;
@@ -44,18 +45,18 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "$PROMPT" ]]; then
+if [ -z "$PROMPT" ]; then
     echo "Error: --prompt is required"
     exit 1
 fi
 
-if [[ -z "$IMAGE_URLS" ]]; then
+if [ -z "$IMAGE_URLS" ]; then
     echo "Error: --image-urls is required (comma-separated URLs, max 14)"
     exit 1
 fi
 
 # Escape prompt for JSON
-PROMPT_ESCAPED=$(echo "$PROMPT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g')
+PROMPT_ESCAPED=$(printf '%s' "$PROMPT" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
 # Convert comma-separated URLs to JSON array
 # Input: "url1,url2,url3"
@@ -66,12 +67,12 @@ IMAGE_URLS_JSON=$(echo "$IMAGE_URLS" | sed 's/,/","/g' | sed 's/^/["/' | sed 's/
 JSON_PAYLOAD="{\"prompt\":\"$PROMPT_ESCAPED\",\"image_urls\":$IMAGE_URLS_JSON,\"num_images\":$NUM_IMAGES,\"aspect_ratio\":\"$ASPECT_RATIO\",\"resolution\":\"$RESOLUTION\",\"output_format\":\"$OUTPUT_FORMAT\"}"
 
 echo "Submitting edit request..."
-echo "Prompt: ${PROMPT:0:100}..."
+printf "Prompt: %.100s...\n" "$PROMPT"
 echo "Reference images: $(echo "$IMAGE_URLS" | tr ',' '\n' | wc -l | tr -d ' ')"
 echo "Settings: $ASPECT_RATIO, $RESOLUTION, $OUTPUT_FORMAT"
 echo ""
 
-# Submit to queue
+# Submit to queue (API_BASE includes /edit for submit)
 SUBMIT_RESPONSE=$(curl -s -X POST "$API_BASE" \
     -H "Authorization: Key $FAL_KEY" \
     -H "Content-Type: application/json" \
@@ -80,7 +81,7 @@ SUBMIT_RESPONSE=$(curl -s -X POST "$API_BASE" \
 # Extract request_id via grep (handles optional space after colon)
 REQUEST_ID=$(echo "$SUBMIT_RESPONSE" | grep -oE '"request_id":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
 
-if [[ -z "$REQUEST_ID" ]]; then
+if [ -z "$REQUEST_ID" ]; then
     echo "Error: Failed to submit request"
     echo "$SUBMIT_RESPONSE"
     exit 1
@@ -89,11 +90,11 @@ fi
 echo "Request ID: $REQUEST_ID"
 echo "Waiting for generation..."
 
-# Poll for completion
+# Poll for completion (STATUS_BASE without /edit for polling)
 MAX_ATTEMPTS=60
 ATTEMPT=0
 
-while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
     STATUS_RESPONSE=$(curl -s "$STATUS_BASE/requests/$REQUEST_ID/status" \
         -H "Authorization: Key $FAL_KEY")
 
@@ -116,24 +117,24 @@ while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
             ATTEMPT=$((ATTEMPT + 1))
             ;;
         *)
-            echo "Status: $STATUS..."
+            echo "Status: $STATUS (unknown, retrying)..."
             sleep 2
             ATTEMPT=$((ATTEMPT + 1))
             ;;
     esac
 done
 
-if [[ $ATTEMPT -ge $MAX_ATTEMPTS ]]; then
+if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
     echo "Error: Timeout waiting for generation"
     exit 1
 fi
 
-# Get result
+# Get result (STATUS_BASE without /edit)
 RESULT=$(curl -s "$STATUS_BASE/requests/$REQUEST_ID" \
     -H "Authorization: Key $FAL_KEY")
 
 # Download images if output_dir specified
-if [[ -n "$OUTPUT_DIR" ]]; then
+if [ -n "$OUTPUT_DIR" ]; then
     mkdir -p "$OUTPUT_DIR"
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
@@ -144,7 +145,7 @@ if [[ -n "$OUTPUT_DIR" ]]; then
     echo "Downloading images..."
     for URL in $URLS; do
         SUFFIX=""
-        [[ $NUM_IMAGES -gt 1 ]] && SUFFIX="_$INDEX"
+        [ "$NUM_IMAGES" -gt 1 ] && SUFFIX="_$INDEX"
         OUTPUT_PATH="$OUTPUT_DIR/${FILENAME}_${TIMESTAMP}${SUFFIX}.${OUTPUT_FORMAT}"
 
         if curl -s -o "$OUTPUT_PATH" "$URL"; then


### PR DESCRIPTION
## Summary
- Replace all bashisms in generate.sh, edit.sh, upload.sh with POSIX sh equivalents
- Scripts now work in cloud sandboxes where bash_tool runs through /bin/sh
- Replaced: [[ ]] to [ ], BASH_SOURCE to $0, source to dot, == to =, substring to printf
- Updated SKILL.md: added Compatibility section, examples use sh instead of bash

## Test plan
- [ ] Run sh -n syntax check on all 3 scripts (passed locally)
- [ ] Test generate.sh in local Claude Code (bash)
- [ ] Test generate.sh in cloud Claude (web /bin/sh)
- [ ] Test edit.sh with reference images
- [ ] Verify upload.sh base64 fallback still works

Generated with Claude Code