### PR TITLE
chore: bump fal-ai-image to 1.1.0

### DIFF
--- a/plugins/fal-ai-image/.claude-plugin/plugin.json
+++ b/plugins/fal-ai-image/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fal-ai-image",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Generate images using fal.ai nano-banana model",
   "author": {
     "name": "Polyakov"


### PR DESCRIPTION
Force plugin cache update to pick up STATUS_BASE fix in edit.sh (separate status polling URL without /edit).