### PR TITLE
feat(codex-review): bind plan verdict to Claude session_id

### DIFF
--- a/plugins/codex-review/.claude-plugin/plugin.json
+++ b/plugins/codex-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review",
   "description": "Cross-agent review workflow: Claude implements, Codex reviews",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Polyakov"
   },

--- a/plugins/codex-review/skills/codex-review/README.md
+++ b/plugins/codex-review/skills/codex-review/README.md
@@ -209,7 +209,7 @@ The plugin works transparently from git worktrees:
 
 When `AUTO_REVIEW=true` in `.codex-review/config.env`, the plugin enforces automated review:
 
-- **Plan phase**: a plugin hook blocks `ExitPlanMode` until `verdict.txt` contains `APPROVED`. If the verdict is missing or not approved, the hook denies the exit and instructs Claude to load the codex-review skill and run plan review first.
+- **Plan phase**: a plugin hook blocks `ExitPlanMode` until Codex approves the plan **AND** the approval was issued in the current Claude session. The hook binds each plan review to the Claude session that ran it, so a stale verdict from a previous task or session cannot silently auto-approve a new plan. If the verdict is missing, stale, not approved, or from a different session, the hook denies the exit and instructs Claude to load the codex-review skill and run plan review first.
 - **Code phase**: after implementation, Claude automatically sends code for review and iterates until approved.
 
 No additional configuration needed — the hook is declared in `plugin.json` and auto-registered when the plugin is enabled.

--- a/plugins/codex-review/skills/codex-review/SKILL.md
+++ b/plugins/codex-review/skills/codex-review/SKILL.md
@@ -156,7 +156,7 @@ bash scripts/codex-state.sh set phase implementing  # Обновить фазу
 
 ## Verdict
 
-Codex пишет свой вердикт в `verdict.txt` внутри state-каталога ветки (одно слово: `APPROVED` или `CHANGES_REQUESTED`). Файл очищается перед каждым запросом ревью. Если Codex не создал файл — скрипт парсит вердикт из текста ответа (fallback).
+Codex пишет свой вердикт в `verdict.txt` внутри state-каталога ветки (одно слово: `APPROVED` или `CHANGES_REQUESTED`). **Для чтения вердикта используй `bash scripts/codex-state.sh get verdict`** — helper возвращает `APPROVED`, `CHANGES_REQUESTED` или пустую строку (нет/невалидно). Файл очищается перед каждым запросом ревью. Если Codex не создал файл — скрипт парсит вердикт из текста ответа (fallback). Плагинный хук `ExitPlanMode` дополнительно связывает вердикт с текущей Claude-сессией через `current_session.txt` в том же каталоге — verdict, пришедший из другой сессии, удаляется.
 
 ## Правила
 
@@ -185,7 +185,7 @@ When `AUTO_REVIEW=true` in `.codex-review/config.env`, the entire review cycle r
    bash scripts/codex-review.sh plan --plan-file ~/.claude/plans/<slug>.md
    ```
    **IMPORTANT**: Always run `init` before the first `plan` review in a conversation. Even if `codex-state.sh show` reports an existing session, it may be stale (from a previous conversation). The `init` command safely archives the old session and creates a fresh one. Only skip `init` when re-submitting after `CHANGES_REQUESTED` within the same review cycle.
-3. **Formal verdict check** — read `verdict.txt` from the state dir (`bash scripts/codex-state.sh dir`). Proceed ONLY if the file contains the exact string `APPROVED`. Do NOT interpret review text — only the literal file content matters.
+3. **Formal verdict check** — run `bash scripts/codex-state.sh get verdict`. Proceed ONLY if it outputs the exact string `APPROVED`. Do NOT interpret review text — only the helper output matters.
 4. `CHANGES_REQUESTED` → fix the plan, resubmit (follow «Accept or Argue» rules). Iterate automatically up to the iteration limit.
 5. `APPROVED` → call `ExitPlanMode` (the hook auto-approves it)
 
@@ -199,7 +199,7 @@ When `AUTO_REVIEW=true` in `.codex-review/config.env`, the entire review cycle r
    ```bash
    bash scripts/codex-review.sh code "code description"
    ```
-8. **Formal verdict check** — same as step 3: read `verdict.txt`, check for exact string `APPROVED`.
+8. **Formal verdict check** — same as step 3: run `bash scripts/codex-state.sh get verdict` and check for exact string `APPROVED`.
 9. `CHANGES_REQUESTED` → fix code, resubmit automatically.
 10. `APPROVED` → work is complete, report to user.
 

--- a/plugins/codex-review/skills/codex-review/scripts/auto-approve-plan.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/auto-approve-plan.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 # PermissionRequest hook for ExitPlanMode.
-# When AUTO_REVIEW=true: auto-approve if verdict.txt=APPROVED,
-# otherwise deny with instruction to load codex-review skill.
-# When AUTO_REVIEW!=true: no output (normal UI dialog).
+#
+# When AUTO_REVIEW=true, this hook binds Codex verdict to the current Claude
+# session via .codex-review/<branch>/current_session.txt:
+#
+#   - session_id missing from stdin     → deny "invalid stdin"
+#   - current_session.txt missing       → claim + deny (untrusted start)
+#   - current_session.txt mismatches    → overwrite + deny (session changed)
+#   - session matches:
+#       * no verdict                     → deny "run plan review"
+#       * APPROVED                       → allow + remove verdict
+#       * CHANGES_REQUESTED               → deny "resubmit"
+#       * unknown value                   → deny "unknown verdict"
+#
+# When AUTO_REVIEW!=true: exit silently (normal UI dialog).
 
 set -e
 
@@ -14,6 +25,7 @@ repo_root="$(cd "$git_common_dir/.." && pwd)"
 # Source in a subshell to match common.sh behavior exactly (handles `export`,
 # leading whitespace, quoted values, etc). Side effects stay isolated.
 config_file="$repo_root/.codex-review/config.env"
+# shellcheck source=/dev/null
 AUTO_REVIEW="$( . "$config_file" 2>/dev/null; echo "${AUTO_REVIEW:-false}" )"
 
 # Not auto mode — exit silently (normal UI dialog)
@@ -26,32 +38,86 @@ branch="$(git symbolic-ref --short HEAD 2>/dev/null)" \
     || branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" \
     || branch="detached"
 branch_slug="$(echo "$branch" | tr '/' '-')"
-verdict_file="$repo_root/.codex-review/$branch_slug/verdict.txt"
+state_dir="$repo_root/.codex-review/$branch_slug"
+mkdir -p "$state_dir"
+verdict_file="$state_dir/verdict.txt"
+session_file="$state_dir/current_session.txt"
 
-# --- Check verdict ---
-# Three branches with distinct deny messages so Claude can recover correctly:
-#   - APPROVED          → allow + cleanup verdict
-#   - present, not APPROVED → deny "resubmit" (already mid-cycle)
-#   - missing           → deny "load skill + run plan review" (cold start)
-if [ -f "$verdict_file" ]; then
-    # Strip whitespace, then restrict to [A-Za-z0-9_] so the value is safe to
-    # interpolate into a JSON string literal below.
-    verdict="$(tr -d '[:space:]' < "$verdict_file" | tr -cd '[:alnum:]_')"
-    if [ "$verdict" = "APPROVED" ]; then
-        rm -f "$verdict_file"
-        cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}
-EOF
-        exit 0
-    fi
-    # Verdict present but not APPROVED — Claude already ran review, must resubmit.
-    # Default to "unknown" if file existed but content was empty/garbage.
-    [ -n "$verdict" ] || verdict="unknown"
-    printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"Codex plan verdict is %s, not APPROVED. Address feedback and resubmit via '\''codex-review.sh plan --plan-file <path>'\'' — do NOT call ExitPlanMode until APPROVED."}}}\n' "$verdict"
+# --- Read hook stdin ---
+stdin_json="$(cat)"
+
+# --- Parse session_id from stdin JSON ---
+# Claude sends a UUID in "session_id". Parse without jq (may not be available
+# in the hook execution environment). Match hex+dash chars only so the value
+# is safe to interpolate into a JSON string literal.
+stdin_session="$(printf '%s' "$stdin_json" \
+    | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[0-9a-fA-F-]+"' \
+    | head -n1 \
+    | sed -E 's/.*"([0-9a-fA-F-]+)"$/\1/')"
+
+# --- Helpers ---
+
+emit_allow() {
+    printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}\n'
+}
+
+# $1: deny message (must be JSON-safe; these are all hardcoded ASCII)
+emit_deny() {
+    printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"%s"}}}\n' "$1"
+}
+
+# Atomically write session_id to current_session.txt (tmp.$$ → mv on same FS).
+claim_session() {
+    tmp="$session_file.tmp.$$"
+    printf '%s\n' "$stdin_session" > "$tmp"
+    mv "$tmp" "$session_file"
+}
+
+# --- Validate stdin ---
+if [ -z "$stdin_session" ]; then
+    emit_deny "Invalid hook stdin: missing session_id. This is an internal error; report it to plugin maintainers."
     exit 0
 fi
 
-# --- Deny: no verdict at all — cold start, instruct to load skill ---
-cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"No Codex plan verdict found. Load skill 'codex-review' and run plan review before ExitPlanMode: init + plan --plan-file <path>."}}}
-EOF
+# --- Check current session binding ---
+if [ ! -f "$session_file" ]; then
+    # 5A: missing claim → untrusted, purge any orphan verdict and claim session
+    rm -f "$verdict_file"
+    claim_session
+    emit_deny "Codex plan review not claimed for this Claude session. Load skill 'codex-review' and run plan review first: init + plan --plan-file <path>."
+    exit 0
+fi
+
+current_session="$(tr -d '[:space:]' < "$session_file" 2>/dev/null || echo "")"
+if [ "$current_session" != "$stdin_session" ]; then
+    # 5B: session mismatch → another Claude session owned this state, stale
+    rm -f "$verdict_file"
+    claim_session
+    emit_deny "Claude session changed. The previous Codex plan verdict belongs to a different session. Load skill 'codex-review' and re-run plan review for this session: init + plan --plan-file <path>."
+    exit 0
+fi
+
+# --- Session matches: consult verdict.txt ---
+
+if [ ! -f "$verdict_file" ]; then
+    emit_deny "No Codex plan verdict found. Load skill 'codex-review' and run plan review before ExitPlanMode: init + plan --plan-file <path>."
+    exit 0
+fi
+
+# Read single-word verdict. Strip whitespace, then restrict to [A-Za-z_]
+# so the value is safe to interpolate into the JSON deny message below.
+verdict="$(tr -d '[:space:]' < "$verdict_file" | tr -cd '[:alpha:]_')"
+
+case "$verdict" in
+    APPROVED)
+        rm -f "$verdict_file"
+        emit_allow
+        ;;
+    CHANGES_REQUESTED)
+        emit_deny "Codex plan verdict is CHANGES_REQUESTED. Address feedback and resubmit via 'codex-review.sh plan --plan-file <path>' — do NOT call ExitPlanMode until APPROVED."
+        ;;
+    *)
+        [ -n "$verdict" ] || verdict="unknown"
+        printf '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"deny","message":"Unknown Codex verdict value: %s. Re-run plan review via '\''codex-review.sh plan --plan-file <path>'\''."}}}\n' "$verdict"
+        ;;
+esac

--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -186,14 +186,12 @@ read_verdict() {
     local output="$1"
     local verdict_file="$STATE_DIR/verdict.txt"
 
-    # Primary: read from verdict file
-    if [[ -f "$verdict_file" ]]; then
-        local file_verdict
-        file_verdict=$(tr -d '[:space:]' < "$verdict_file")
-        if [[ "$file_verdict" == "APPROVED" || "$file_verdict" == "CHANGES_REQUESTED" ]]; then
-            echo "$file_verdict"
-            return
-        fi
+    # Primary: read from verdict file (format-agnostic via helper)
+    local file_verdict
+    file_verdict="$(parse_verdict_file "$verdict_file")"
+    if [[ "$file_verdict" == "APPROVED" || "$file_verdict" == "CHANGES_REQUESTED" ]]; then
+        echo "$file_verdict"
+        return
     fi
 
     # Fallback: parse response text

--- a/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
@@ -53,6 +53,10 @@ cmd_get() {
         get_effective_session_id
         return
     fi
+    if [[ "$field" == "verdict" ]]; then
+        parse_verdict_file "$STATE_DIR/verdict.txt"
+        return
+    fi
     local val
     val="$(read_state_field "$field")"
     if [[ -z "$val" ]]; then
@@ -100,7 +104,7 @@ case "${1:-}" in
         echo "  dir               Print state directory path for current branch"
         echo "  reset             Reset iterations/phase (keep session_id)"
         echo "  reset --full      Full reset + delete notes"
-        echo "  get <field>       Get a single field"
+        echo "  get <field>       Get a single field (special: 'verdict' reads verdict.txt)"
         echo "  set <field> <val> Set a field (e.g. session_id)"
         exit 1
         ;;

--- a/plugins/codex-review/skills/codex-review/scripts/common.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/common.sh
@@ -178,6 +178,20 @@ remove_status() {
     rm -f "$state_dir/STATUS.md"
 }
 
+# --- Parse verdict file ---
+# Reads single-word verdict file and prints normalized verdict string.
+# Output: "APPROVED", "CHANGES_REQUESTED", or empty for missing/unknown.
+parse_verdict_file() {
+    local file="$1"
+    [[ -f "$file" ]] || return 0
+    local raw
+    raw="$(tr -d '[:space:]' < "$file")"
+    case "$raw" in
+        APPROVED|CHANGES_REQUESTED) echo "$raw" ;;
+        *) : ;;
+    esac
+}
+
 # --- Archive previous session artifacts ---
 archive_previous_session() {
     local state_dir
@@ -235,10 +249,8 @@ generate_archive_summary() {
             | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//')"
     fi
 
-    # Read final verdict
-    if [[ -f "$state_dir/verdict.txt" ]]; then
-        final_verdict="$(tr -d '[:space:]' < "$state_dir/verdict.txt")"
-    fi
+    # Read final verdict via format-agnostic helper
+    final_verdict="$(parse_verdict_file "$state_dir/verdict.txt")"
     if [[ -z "$final_verdict" ]]; then
         final_verdict="$last_status"
     fi

--- a/plugins/codex-review/test/test-auto-approve-plan.sh
+++ b/plugins/codex-review/test/test-auto-approve-plan.sh
@@ -24,19 +24,40 @@ BRANCH_SLUG="main"
 PASS=0
 FAIL=0
 
-assert_output() {
-    local test_name="$1"
-    local expected="$2"
-    local actual="$3"
+# Stable fake session IDs for tests
+SID_A="11111111-1111-1111-1111-111111111111"
+SID_B="22222222-2222-2222-2222-222222222222"
 
-    if [ "$actual" = "$expected" ]; then
+# Build hook stdin JSON with a given session_id
+hook_stdin() {
+    printf '{"session_id":"%s","hook_event_name":"PermissionRequest","tool_name":"ExitPlanMode"}\n' "$1"
+}
+
+# Write a verdict file (single-word content)
+write_verdict() {
+    _wv_path="$1"
+    _wv_val="$2"
+    printf '%s' "$_wv_val" > "$_wv_path"
+}
+
+# Claim the branch's current_session.txt for a given session id
+claim_session_file() {
+    printf '%s\n' "$1" > ".codex-review/$2/current_session.txt"
+}
+
+assert_output() {
+    _ao_test_name="$1"
+    _ao_expected="$2"
+    _ao_actual="$3"
+
+    if [ "$_ao_actual" = "$_ao_expected" ]; then
         PASS=$((PASS + 1))
-        printf "  PASS: %s\n" "$test_name"
+        printf "  PASS: %s\n" "$_ao_test_name"
     else
         FAIL=$((FAIL + 1))
-        printf "  FAIL: %s\n" "$test_name"
-        printf "    expected: %s\n" "$expected"
-        printf "    actual:   %s\n" "$actual"
+        printf "  FAIL: %s\n" "$_ao_test_name"
+        printf "    expected: %s\n" "$_ao_expected"
+        printf "    actual:   %s\n" "$_ao_actual"
     fi
 }
 
@@ -50,20 +71,20 @@ elif command -v jq >/dev/null 2>&1; then
 fi
 
 assert_valid_json() {
-    local test_name="$1"
-    local payload="$2"
+    _avj_test_name="$1"
+    _avj_payload="$2"
 
     if [ -z "$JSON_VALIDATOR" ]; then
-        printf "  SKIP: %s (no python3/jq available)\n" "$test_name"
+        printf "  SKIP: %s (no python3/jq available)\n" "$_avj_test_name"
         return 0
     fi
-    if printf '%s' "$payload" | sh -c "$JSON_VALIDATOR" >/dev/null 2>&1; then
+    if printf '%s' "$_avj_payload" | sh -c "$JSON_VALIDATOR" >/dev/null 2>&1; then
         PASS=$((PASS + 1))
-        printf "  PASS: %s\n" "$test_name"
+        printf "  PASS: %s\n" "$_avj_test_name"
     else
         FAIL=$((FAIL + 1))
-        printf "  FAIL: %s (invalid JSON)\n" "$test_name"
-        printf "    payload: %s\n" "$payload"
+        printf "  FAIL: %s (invalid JSON)\n" "$_avj_test_name"
+        printf "    payload: %s\n" "$_avj_payload"
     fi
 }
 
@@ -97,34 +118,43 @@ output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
 assert_output "empty output (passthrough)" "" "$output"
 
 # ============================
-# Test 3: AUTO_REVIEW=true, no verdict.txt — deny (cold start)
+# Test 3: AUTO_REVIEW=true, no verdict, no current_session — deny (cold start, claim)
 # ============================
-printf "Test 3: AUTO_REVIEW=true, no verdict (cold start)\n"
+printf "Test 3: AUTO_REVIEW=true, no verdict, no session file (cold start)\n"
 printf 'AUTO_REVIEW=true\n' > .codex-review/config.env
 mkdir -p ".codex-review/$BRANCH_SLUG"
 rm -f ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+rm -f ".codex-review/$BRANCH_SLUG/current_session.txt"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 assert_valid_json "cold-start payload is valid JSON" "$output"
 case "$output" in
     *'"behavior":"deny"'*) assert_output "deny decision" "yes" "yes" ;;
     *) assert_output "deny decision" "contains behavior:deny" "$output" ;;
 esac
-# Cold-start message must instruct to load skill and run plan review
+# Cold-start message must mention "not claimed" and skill instructions
 case "$output" in
-    *"No Codex plan verdict found"*) assert_output "cold-start message" "yes" "yes" ;;
-    *) assert_output "cold-start message" "contains 'No Codex plan verdict found'" "$output" ;;
+    *"not claimed"*) assert_output "cold-start 'not claimed'" "yes" "yes" ;;
+    *) assert_output "cold-start 'not claimed'" "contains 'not claimed'" "$output" ;;
 esac
 case "$output" in
     *"Load skill 'codex-review'"*) assert_output "cold-start mentions skill" "yes" "yes" ;;
     *) assert_output "cold-start mentions skill" "contains skill load" "$output" ;;
 esac
+# Session file must be claimed after the call
+if [ -f ".codex-review/$BRANCH_SLUG/current_session.txt" ]; then
+    claimed="$(tr -d '[:space:]' < ".codex-review/$BRANCH_SLUG/current_session.txt")"
+    assert_output "current_session.txt claimed with stdin session_id" "$SID_A" "$claimed"
+else
+    assert_output "current_session.txt created" "yes" "no"
+fi
 
 # ============================
-# Test 4: AUTO_REVIEW=true, verdict=CHANGES_REQUESTED — deny (resubmit)
+# Test 4: matching session + CHANGES_REQUESTED — deny (resubmit)
 # ============================
-printf "Test 4: AUTO_REVIEW=true, verdict=CHANGES_REQUESTED (resubmit)\n"
-printf 'CHANGES_REQUESTED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+printf "Test 4: AUTO_REVIEW=true, CHANGES_REQUESTED (resubmit)\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "CHANGES_REQUESTED"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 assert_valid_json "resubmit payload is valid JSON" "$output"
 case "$output" in
     *'"behavior":"deny"'*) assert_output "deny decision" "yes" "yes" ;;
@@ -132,25 +162,26 @@ case "$output" in
 esac
 # Resubmit message must contain the verdict value and resubmit instruction
 case "$output" in
-    *"verdict is CHANGES_REQUESTED"*) assert_output "verdict value in message" "yes" "yes" ;;
-    *) assert_output "verdict value in message" "contains 'verdict is CHANGES_REQUESTED'" "$output" ;;
+    *"CHANGES_REQUESTED"*) assert_output "verdict value in message" "yes" "yes" ;;
+    *) assert_output "verdict value in message" "contains 'CHANGES_REQUESTED'" "$output" ;;
 esac
 case "$output" in
     *"resubmit"*) assert_output "resubmit instruction" "yes" "yes" ;;
     *) assert_output "resubmit instruction" "contains 'resubmit'" "$output" ;;
 esac
-# Cold-start message must NOT appear in this branch
+# Cold-start "not claimed" must NOT appear in this branch
 case "$output" in
-    *"No Codex plan verdict found"*) assert_output "no cold-start mix-up" "absent" "present" ;;
+    *"not claimed"*) assert_output "no cold-start mix-up" "absent" "present" ;;
     *) assert_output "no cold-start mix-up" "yes" "yes" ;;
 esac
 
 # ============================
-# Test 5: AUTO_REVIEW=true, verdict=APPROVED — allow
+# Test 5: matching session + APPROVED — allow
 # ============================
-printf "Test 5: AUTO_REVIEW=true, verdict=APPROVED — allow + cleanup\n"
-printf 'APPROVED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+printf "Test 5: AUTO_REVIEW=true, APPROVED — allow + cleanup\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 assert_valid_json "allow payload is valid JSON" "$output"
 case "$output" in
     *'"behavior":"allow"'*) assert_output "allow decision" "yes" "yes" ;;
@@ -162,13 +193,21 @@ if [ -f ".codex-review/$BRANCH_SLUG/verdict.txt" ]; then
 else
     assert_output "verdict.txt deleted after allow" "yes" "yes"
 fi
+# current_session.txt must survive (so next ExitPlanMode in the same session
+# does not waste a claim cycle)
+if [ -f ".codex-review/$BRANCH_SLUG/current_session.txt" ]; then
+    assert_output "current_session.txt preserved after allow" "yes" "yes"
+else
+    assert_output "current_session.txt preserved after allow" "yes" "no"
+fi
 
 # ============================
-# Test 6: AUTO_REVIEW=true, verdict=APPROVED with whitespace — allow
+# Test 6: APPROVED with whitespace — allow
 # ============================
 printf "Test 6: verdict with trailing whitespace\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
 printf '  APPROVED \n' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 case "$output" in
     *'"behavior":"allow"'*) assert_output "allow despite whitespace" "yes" "yes" ;;
     *) assert_output "allow despite whitespace" "contains behavior:allow" "$output" ;;
@@ -179,8 +218,9 @@ esac
 # ============================
 printf "Test 7: AUTO_REVIEW with quotes\n"
 printf 'AUTO_REVIEW="true"\n' > .codex-review/config.env
-printf 'APPROVED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 case "$output" in
     *'"behavior":"allow"'*) assert_output "quoted value parsed" "yes" "yes" ;;
     *) assert_output "quoted value parsed" "contains behavior:allow" "$output" ;;
@@ -202,8 +242,9 @@ BRANCH_SLUG2="feat-my-feature"
 mkdir -p ".codex-review"
 printf 'AUTO_REVIEW=true\n' > .codex-review/config.env
 mkdir -p ".codex-review/$BRANCH_SLUG2"
-printf 'APPROVED' > ".codex-review/$BRANCH_SLUG2/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG2/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG2/verdict.txt" "APPROVED"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 case "$output" in
     *'"behavior":"allow"'*) assert_output "allow with commits + slash branch" "yes" "yes" ;;
     *) assert_output "allow with commits + slash branch" "contains behavior:allow" "$output" ;;
@@ -216,18 +257,24 @@ rm -rf "$TEST_DIR2"
 # ============================
 printf "Test 9: stale verdict protection\n"
 printf 'AUTO_REVIEW=true\n' > .codex-review/config.env
-printf 'APPROVED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
 # First call — allow (and delete verdict.txt)
-output1="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+output1="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 case "$output1" in
     *'"behavior":"allow"'*) assert_output "first call: allow" "yes" "yes" ;;
     *) assert_output "first call: allow" "contains behavior:allow" "$output1" ;;
 esac
-# Second call — must deny (no verdict.txt left)
-output2="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+# Second call — must deny (no verdict.txt left, but session still claimed)
+output2="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 case "$output2" in
     *'"behavior":"deny"'*) assert_output "second call: deny (no stale verdict)" "yes" "yes" ;;
     *) assert_output "second call: deny (no stale verdict)" "contains behavior:deny" "$output2" ;;
+esac
+# Should be the "no verdict" path, not "not claimed"
+case "$output2" in
+    *"No Codex plan verdict found"*) assert_output "second call: no-verdict path" "yes" "yes" ;;
+    *) assert_output "second call: no-verdict path" "contains 'No Codex plan verdict found'" "$output2" ;;
 esac
 
 # ============================
@@ -237,8 +284,9 @@ esac
 # while common.sh (which uses `.`) honored it. Hook now sources too.
 printf "Test 10: parser regression — 'export AUTO_REVIEW=true'\n"
 printf 'export AUTO_REVIEW=true\n' > .codex-review/config.env
-printf 'APPROVED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 case "$output" in
     *'"behavior":"allow"'*) assert_output "'export' form honored" "yes" "yes" ;;
     *) assert_output "'export' form honored" "contains behavior:allow" "$output" ;;
@@ -249,8 +297,9 @@ esac
 # ============================
 printf "Test 11: parser regression — leading whitespace\n"
 printf '  AUTO_REVIEW=true\n' > .codex-review/config.env
-printf 'APPROVED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 case "$output" in
     *'"behavior":"allow"'*) assert_output "leading whitespace honored" "yes" "yes" ;;
     *) assert_output "leading whitespace honored" "contains behavior:allow" "$output" ;;
@@ -263,10 +312,12 @@ printf 'AUTO_REVIEW=true\n' > .codex-review/config.env
 # Test 12: sanitization — verdict with JSON-breaking quotes
 # ============================
 # Raw `"` inside verdict.txt would break the JSON string literal in the deny
-# payload if not stripped. `tr -cd '[:alnum:]_'` must remove it.
+# payload if not stripped. `tr -cd '[:alpha:]_'` must remove it. Falls into
+# the "unknown verdict" branch after sanitization.
 printf "Test 12: sanitization — verdict with double quotes\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
 printf 'CHANGES"REQUESTED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 assert_valid_json "payload with quoted verdict is valid JSON" "$output"
 msg="$(extract_message "$output")"
 case "$msg" in
@@ -281,12 +332,17 @@ esac
 # Raw `\` would escape the following char in a JSON string literal. Must be
 # stripped before interpolation.
 printf "Test 13: sanitization — verdict with backslash\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
 printf 'CHANGES\\REQUESTED' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 assert_valid_json "payload with backslash verdict is valid JSON" "$output"
 msg="$(extract_message "$output")"
+# Build the literal backslash via printf so shellcheck doesn't flag the
+# pattern as an ambiguous single-quote escape (SC1003 false positive on
+# `*'\\'*` or `bs='\'`).
+bs="$(printf '\134')"
 case "$msg" in
-    *'\\'*) assert_output "backslash stripped from message" "no backslash" "FOUND: $msg" ;;
+    *"$bs"*) assert_output "backslash stripped from message" "no backslash" "FOUND: $msg" ;;
     *CHANGESREQUESTED*) assert_output "sanitized verdict in message" "yes" "yes" ;;
     *) assert_output "sanitized verdict in message" "contains CHANGESREQUESTED" "$msg" ;;
 esac
@@ -294,28 +350,30 @@ esac
 # ============================
 # Test 14: sanitization fallback — all-garbage verdict → "unknown"
 # ============================
-# verdict.txt with only non-alnum chars → sanitized to empty → fallback.
+# verdict.txt with only non-alpha chars → sanitized to empty → fallback label.
 printf "Test 14: fallback — all-garbage verdict\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
 printf '!!!@@@###' > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 assert_valid_json "payload with garbage verdict is valid JSON" "$output"
 msg="$(extract_message "$output")"
 case "$msg" in
-    *"verdict is unknown"*) assert_output "unknown fallback in message" "yes" "yes" ;;
-    *) assert_output "unknown fallback in message" "contains 'verdict is unknown'" "$msg" ;;
+    *"Unknown Codex verdict value: unknown"*) assert_output "unknown fallback in message" "yes" "yes" ;;
+    *) assert_output "unknown fallback in message" "contains 'Unknown Codex verdict value: unknown'" "$msg" ;;
 esac
 
 # ============================
 # Test 15: sanitization fallback — empty verdict file → "unknown"
 # ============================
 printf "Test 15: fallback — empty verdict file\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
 : > ".codex-review/$BRANCH_SLUG/verdict.txt"
-output="$(echo '{}' | sh "$HOOK" 2>/dev/null)" || true
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
 assert_valid_json "payload with empty verdict is valid JSON" "$output"
 msg="$(extract_message "$output")"
 case "$msg" in
-    *"verdict is unknown"*) assert_output "unknown fallback in message" "yes" "yes" ;;
-    *) assert_output "unknown fallback in message" "contains 'verdict is unknown'" "$msg" ;;
+    *"Unknown Codex verdict value: unknown"*) assert_output "unknown fallback in message" "yes" "yes" ;;
+    *) assert_output "unknown fallback in message" "contains 'Unknown Codex verdict value: unknown'" "$msg" ;;
 esac
 
 # ============================
@@ -337,6 +395,118 @@ if [ -f "$PLUGIN_JSON" ]; then
 else
     assert_output "plugin.json exists" "yes" "no"
 fi
+
+# Ensure plain config for session-binding tests
+printf 'AUTO_REVIEW=true\n' > .codex-review/config.env
+
+# ============================
+# Test 17: session mismatch — deny + overwrite current_session.txt
+# ============================
+printf "Test 17: session mismatch (different stdin session_id)\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+output="$(hook_stdin "$SID_B" | sh "$HOOK" 2>/dev/null)" || true
+assert_valid_json "mismatch payload is valid JSON" "$output"
+case "$output" in
+    *'"behavior":"deny"'*) assert_output "mismatch: deny" "yes" "yes" ;;
+    *) assert_output "mismatch: deny" "contains behavior:deny" "$output" ;;
+esac
+case "$output" in
+    *"Claude session changed"*) assert_output "mismatch message" "yes" "yes" ;;
+    *) assert_output "mismatch message" "contains 'Claude session changed'" "$output" ;;
+esac
+# current_session.txt must be overwritten with the new (stdin) session_id
+claimed="$(tr -d '[:space:]' < ".codex-review/$BRANCH_SLUG/current_session.txt")"
+assert_output "current_session.txt overwritten with stdin sid" "$SID_B" "$claimed"
+# Stale verdict from previous session must be purged
+if [ -f ".codex-review/$BRANCH_SLUG/verdict.txt" ]; then
+    assert_output "stale verdict purged on mismatch" "deleted" "still exists"
+else
+    assert_output "stale verdict purged on mismatch" "yes" "yes"
+fi
+
+# ============================
+# Test 18: unknown verdict value (alpha, no sanitization) — deny
+# ============================
+# Complements Tests 14/15 which exercise the unknown branch via sanitization.
+# This one feeds a clean alpha value that survives `tr -cd '[:alpha:]_'` intact
+# but is neither APPROVED nor CHANGES_REQUESTED.
+printf "Test 18: unknown verdict value\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "MAYBE"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
+case "$output" in
+    *'"behavior":"deny"'*) assert_output "unknown verdict: deny" "yes" "yes" ;;
+    *) assert_output "unknown verdict: deny" "contains behavior:deny" "$output" ;;
+esac
+case "$output" in
+    *"Unknown Codex verdict"*) assert_output "unknown verdict message" "yes" "yes" ;;
+    *) assert_output "unknown verdict message" "contains 'Unknown Codex verdict'" "$output" ;;
+esac
+
+# ============================
+# Test 19: invalid stdin (missing session_id) — deny
+# ============================
+printf "Test 19: invalid stdin (no session_id)\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+output="$(printf '{}\n' | sh "$HOOK" 2>/dev/null)" || true
+case "$output" in
+    *'"behavior":"deny"'*) assert_output "invalid stdin: deny" "yes" "yes" ;;
+    *) assert_output "invalid stdin: deny" "contains behavior:deny" "$output" ;;
+esac
+case "$output" in
+    *"Invalid hook stdin"*) assert_output "invalid stdin message" "yes" "yes" ;;
+    *) assert_output "invalid stdin message" "contains 'Invalid hook stdin'" "$output" ;;
+esac
+# verdict.txt MUST NOT be touched when stdin is invalid (fail-closed, no side effect)
+if [ -f ".codex-review/$BRANCH_SLUG/verdict.txt" ]; then
+    assert_output "verdict preserved on invalid stdin" "yes" "yes"
+else
+    assert_output "verdict preserved on invalid stdin" "yes" "no"
+fi
+
+# ============================
+# Test 20: cold-start claim does NOT leak previous verdict
+# ============================
+printf "Test 20: cold start purges orphan verdict\n"
+rm -f ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+output="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
+case "$output" in
+    *'"behavior":"deny"'*) assert_output "cold-start with orphan verdict: deny" "yes" "yes" ;;
+    *) assert_output "cold-start with orphan verdict: deny" "contains behavior:deny" "$output" ;;
+esac
+case "$output" in
+    *"not claimed"*) assert_output "cold-start message (orphan)" "yes" "yes" ;;
+    *) assert_output "cold-start message (orphan)" "contains 'not claimed'" "$output" ;;
+esac
+# Orphan verdict must be purged (cannot trust any verdict without a session claim)
+if [ -f ".codex-review/$BRANCH_SLUG/verdict.txt" ]; then
+    assert_output "orphan verdict purged on cold start" "deleted" "still exists"
+else
+    assert_output "orphan verdict purged on cold start" "yes" "yes"
+fi
+
+# ============================
+# Test 21: second call in same session after successful allow yields deny, not allow
+# ============================
+# Redundant safety check: covers the end-to-end stale-verdict replay scenario
+# from a different angle — verifies that an attacker who saves the "allowed"
+# response cannot replay it (because verdict.txt is consumed).
+printf "Test 21: allow is one-shot (no replay)\n"
+printf '%s\n' "$SID_A" > ".codex-review/$BRANCH_SLUG/current_session.txt"
+write_verdict ".codex-review/$BRANCH_SLUG/verdict.txt" "APPROVED"
+first="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
+second="$(hook_stdin "$SID_A" | sh "$HOOK" 2>/dev/null)" || true
+case "$first" in
+    *'"behavior":"allow"'*) assert_output "replay test: first allow" "yes" "yes" ;;
+    *) assert_output "replay test: first allow" "contains behavior:allow" "$first" ;;
+esac
+case "$second" in
+    *'"behavior":"deny"'*) assert_output "replay test: second deny" "yes" "yes" ;;
+    *) assert_output "replay test: second deny" "contains behavior:deny" "$second" ;;
+esac
 
 # ============================
 # Summary

--- a/plugins/codex-review/test/test-e2e.sh
+++ b/plugins/codex-review/test/test-e2e.sh
@@ -124,8 +124,16 @@ assert_eq() {
     fi
 }
 
+# Fake Claude session_id used across all hook calls in a scenario.
+# Must match the hook's stdin regex (hex + dashes only).
+SID_E2E="abcdef01-2345-6789-abcd-ef01e2ee2ee2"
+
+hook_stdin() {
+    printf '{"session_id":"%s","hook_event_name":"PermissionRequest","tool_name":"ExitPlanMode"}\n' "$1"
+}
+
 run_hook_in() {
-    (cd "$1" && echo '{}' | sh "$HOOK" 2>/dev/null) || true
+    (cd "$1" && hook_stdin "$SID_E2E" | sh "$HOOK" 2>/dev/null) || true
 }
 
 init_test_repo() {
@@ -137,8 +145,13 @@ init_test_repo() {
         git config user.email "e2e@test.com"
         git config user.name "E2E Test"
         git commit -q --allow-empty -m "init"
-        mkdir -p .codex-review
+        mkdir -p .codex-review/main
         printf 'AUTO_REVIEW=true\n' > .codex-review/config.env
+        # Pre-claim the session. Simulates a Claude session that has already
+        # touched the hook once and thus owns the current state dir. Without
+        # this, every first hook call in a scenario would cold-start and
+        # purge any verdict.txt written by codex-review.sh.
+        printf '%s\n' "$SID_E2E" > .codex-review/main/current_session.txt
     )
 }
 
@@ -152,11 +165,13 @@ scenario_approve() {
     RA="$TMPDIR_BASE/test-e2e-approve-$$"
     init_test_repo "$RA"
 
-    # --- A1: cold-start (no init yet, no verdict) ---
-    printf "A1: cold-start hook should deny\n"
+    # --- A1: session claimed but no review yet → deny "no verdict" ---
+    # init_test_repo pre-claims the session, so this call hits the
+    # "matching session + missing verdict.txt" branch, not cold-start.
+    printf "A1: pre-init hook should deny (no verdict)\n"
     out_a1="$(run_hook_in "$RA")"
     assert_contains "hook denies before any review" "$out_a1" '"behavior":"deny"'
-    assert_contains "cold-start message" "$out_a1" "No Codex plan verdict found"
+    assert_contains "no-verdict message" "$out_a1" "No Codex plan verdict found"
 
     # --- A2: init + plan with approve fixture ---
     printf "A2: init + plan (approve fixture)\n"
@@ -423,8 +438,8 @@ NOTE
     fi
 
     # 4. Bonus (informational, non-fatal) — fresh plan-review note exists
-    fresh_note="$(find "$state_dir_s/notes" -type f -name "plan-review-*.md" 2>/dev/null \
-        | xargs -I{} grep -L "STALE" {} 2>/dev/null | head -1)"
+    fresh_note="$(find "$state_dir_s/notes" -type f -name "plan-review-*.md" \
+        -exec grep -L "STALE" {} + 2>/dev/null | head -1)"
     if [ -n "$fresh_note" ]; then
         printf "  INFO: fresh plan-review note created (full plan review ran)\n"
     else

--- a/plugins/codex-review/test/test-integration.sh
+++ b/plugins/codex-review/test/test-integration.sh
@@ -54,9 +54,23 @@ assert_allow() {
     esac
 }
 
+# Stable fake session_id for integration tests. Must match the hook's stdin
+# regex: hex chars + dashes only (mirrors real Claude UUID format).
+SID_INT="abcdef01-2345-6789-abcd-ef0123456789"
+
+hook_stdin() {
+    printf '{"session_id":"%s","hook_event_name":"PermissionRequest","tool_name":"ExitPlanMode"}\n' "$1"
+}
+
 run_hook_in() {
-    # Run hook from the given directory with empty stdin.
-    (cd "$1" && echo '{}' | sh "$HOOK" 2>/dev/null) || true
+    # Run hook from the given directory with a valid session_id in stdin.
+    (cd "$1" && hook_stdin "$SID_INT" | sh "$HOOK" 2>/dev/null) || true
+}
+
+# Claim the session in the given state dir so the hook can proceed past
+# the session-binding guard and actually read verdict.txt.
+claim_session_in() {
+    printf '%s\n' "$SID_INT" > "$1/current_session.txt"
 }
 
 git_init_repo() {
@@ -91,6 +105,7 @@ state_dir="$(cd "$T1" && bash "$STATE_CMD" dir)"
 assert_eq "codex-state.sh dir = <repo>/.codex-review/main" \
     "$T1/.codex-review/main" "$state_dir"
 
+claim_session_in "$state_dir"
 printf 'APPROVED' > "$state_dir/verdict.txt"
 out1="$(run_hook_in "$T1")"
 assert_allow "hook reads verdict from same dir" "$out1"
@@ -112,6 +127,7 @@ state_dir2="$(cd "$T2" && bash "$STATE_CMD" dir)"
 assert_eq "slash → dash in dir name" \
     "$T2/.codex-review/feat-my-feature" "$state_dir2"
 
+claim_session_in "$state_dir2"
 printf 'APPROVED' > "$state_dir2/verdict.txt"
 out2="$(run_hook_in "$T2")"
 assert_allow "hook reads from slash-normalized dir" "$out2"
@@ -135,6 +151,7 @@ state_dir3="$(cd "$T3" && bash "$STATE_CMD" dir)"
 assert_eq "no-commit repo uses branch name, not 'HEAD'" \
     "$T3/.codex-review/main" "$state_dir3"
 
+claim_session_in "$state_dir3"
 printf 'APPROVED' > "$state_dir3/verdict.txt"
 out3="$(run_hook_in "$T3")"
 assert_allow "hook allows in no-commit repo" "$out3"
@@ -163,6 +180,7 @@ state_dir4="$(cd "$T4-wt" && bash "$STATE_CMD" dir)"
 assert_eq "worktree state dir lives in MAIN repo" \
     "$T4/.codex-review/feat-wt" "$state_dir4"
 
+claim_session_in "$state_dir4"
 printf 'APPROVED' > "$state_dir4/verdict.txt"
 out4="$(run_hook_in "$T4-wt")"
 assert_allow "hook (run from worktree) reads main-repo verdict" "$out4"


### PR DESCRIPTION
## Summary

The `auto-approve-plan.sh` PermissionRequest hook previously allowed `ExitPlanMode` as soon as `verdict.txt` contained `APPROVED`. A stale verdict from a prior task — left behind by a crash, a manual session close, or a bug in cleanup — could therefore silently auto-approve the next plan in an **unrelated Claude session**. The existing commits (`bcd3757`, `54686e9`, `911c60c`, `490ff62`) closed known paths that produced stale verdicts, but did not address the underlying class of problem: the hook had no way to tell *“this verdict belongs to the current Claude context”* from *“this verdict is a leftover”*.

This PR binds each plan verdict to the Claude `session_id` that produced it. The hook now claims the branch state dir via `current_session.txt` on the first call and validates every subsequent call against the `session_id` it receives on stdin. On any mismatch (including orphan state or missing claim) the stale `verdict.txt` is purged and the call is denied.

Version bumped `1.1.0 → 1.2.0` (minor) because the hook contract is now strictly stronger — same `APPROVED` value that used to allow can now deny if the session doesn't match.

## Changes

### Hook rewrite (`scripts/auto-approve-plan.sh`)
- Parse `session_id` from hook stdin (hex + dash regex, no `jq`).
- Six distinct outcome branches:
  1. **Invalid stdin** (missing `session_id`) → deny, no side effect (fail-closed).
  2. **No `current_session.txt`** → purge any orphan `verdict.txt`, claim session atomically (`tmp.$$` → `mv`), deny with *"not claimed"*.
  3. **Session mismatch** → purge stale `verdict.txt`, overwrite `current_session.txt`, deny with *"Claude session changed"*.
  4. **Match + no verdict** → deny with *"No Codex plan verdict found"*.
  5. **Match + `APPROVED`** → delete `verdict.txt` (one-shot), allow.
  6. **Match + `CHANGES_REQUESTED`** → deny with resubmit instruction.
  7. (default) **Match + unknown/sanitized** → deny with the sanitized value interpolated (safe — value is restricted to `[:alpha:]_`).
- `current_session.txt` is atomically written; `archive_previous_session` already excludes it from the allowlist, so it survives `codex-review init` (re-plans in the same session don't waste a claim cycle).

### Format abstraction (`scripts/common.sh`, `scripts/codex-state.sh`, `scripts/codex-review.sh`)
- New helper `parse_verdict_file` in `common.sh` reads the single-word verdict file and returns a normalized logical verdict (`APPROVED` / `CHANGES_REQUESTED` / empty). Lets future format changes land in one place.
- `generate_archive_summary` routes through it instead of an inline `tr`.
- `codex-review.sh::read_verdict` uses it as the primary source, falling back to response-text parsing only if the file is absent/unreadable.
- `codex-state.sh get verdict` — new subcommand used by `SKILL.md` so Claude reads verdicts without touching the file format directly.

### Skill-side docs (`SKILL.md`, `README.md`)
- `SKILL.md` formal verdict check (plan + code phases) now runs `bash scripts/codex-state.sh get verdict` instead of grepping `verdict.txt`.
- `README.md` AUTO_REVIEW section explicitly states that the hook requires *both* an `APPROVED` verdict *and* a matching session claim.

### Tests
- **`test/test-auto-approve-plan.sh`** — 48 assertions across 21 scenarios (was 33 across 16). New coverage:
  - Cold-start orphan purge
  - Session mismatch + stale verdict purge + session overwrite
  - Unknown verdict (alpha, no sanitization)
  - Invalid stdin (no `session_id`)
  - One-shot replay: second call after successful allow denies with *"no verdict"*
  - Existing sanitization/fallback tests (12–15) updated to claim a session before running, so the hook can reach the verdict branch.
  - `SC1003` fix: literal backslash built via `printf '\134'`.
- **`test/test-integration.sh`** — `run_hook_in` now supplies a valid `session_id`; each scenario pre-claims the state dir via `claim_session_in`. All 4 path-contract scenarios still pass.
- **`test/test-e2e.sh`** — `init_test_repo` pre-claims the session so `scenario_approve` / `scenario_reject` exercise the matching-session path end-to-end. `scenario_stale` is unaffected (doesn't invoke the hook in `-p` mode). `SC2038` fix: `find -exec ... +` instead of `find | xargs`.

## Test results

All three test suites run clean on this branch:

| Suite                         | Result                        |
|-------------------------------|-------------------------------|
| `test-auto-approve-plan.sh`   | **48 passed, 0 failed** (21 scenarios) |
| `test-integration.sh`         | **8 passed, 0 failed** (4 scenarios)  |
| `test-e2e.sh` (`CODEX_E2E=1`) | **18 passed, 0 failed** (approve + reject + stale — real codex + real claude) |
| `shellcheck` (all 7 modified scripts, default severity) | **exit=0** |

## Migration notes

- **Existing installations with a `verdict.txt` but no `current_session.txt`**: first hook call after the upgrade hits the cold-start branch — claims the session, purges the orphan verdict, denies with *"not claimed"*. User re-runs `codex-review plan`, gets a fresh verdict, second hook call allows. One *(explicit and clearly-messaged)* lost cycle, by design (strict missing-claim = untrusted).
- **Existing `current_session.txt` from an older Claude session**: first hook call triggers the mismatch branch — purges stale verdict, overwrites the claim with the new `session_id`, denies. Same pattern: re-run review, then allow.
- No config migration, no backwards-compatibility shims. The file format of `verdict.txt` is unchanged (plain single-word).

## Risk / blast radius

- Hook is the **only** place that reads `session_id` from stdin. Skills and `codex-review.sh` are untouched in terms of session handling.
- `archive_previous_session` is unchanged — it already used an explicit allowlist, so `current_session.txt` naturally survives archiving.
- No new runtime dependencies (parsing is `grep` + `sed`, no `jq`).
- Worktree-safe: `STATE_DIR` continues to resolve via `git rev-parse --git-common-dir` for both the hook and `codex-state.sh dir`.