### PR TITLE
[codex] Refactor x-research config loading

### DIFF
--- a/plugins/x-research/skills/x-research/SKILL.md
+++ b/plugins/x-research/skills/x-research/SKILL.md
@@ -21,6 +21,7 @@ cp config/.env.example config/.env
 ```
 
 Edit `config/.env`: paste your key into `XAI_API_KEY`, configure accounts and topics.
+Quote any value that contains spaces so the file stays shell-compatible.
 
 **Without `.env`:** skill works with explicit `--accounts`, `--query`, `--topics`.
 

--- a/plugins/x-research/skills/x-research/config/.env.example
+++ b/plugins/x-research/skills/x-research/config/.env.example
@@ -1,6 +1,7 @@
 # X Research — config
 # Copy to .env to enable: cp .env.example .env
 # Without .env the skill still works — just pass --accounts and --query explicitly.
+# Keep the file shell-compatible: quote any value that contains spaces.
 
 # ─── API credentials ─────────────────────────────────────────
 # Get your key at https://console.x.ai/
@@ -32,6 +33,10 @@ X_TOPICS_AI=AI,LLM,GPT,Claude,agents,AGI
 # X_ACCOUNTS_CRYPTO_LABEL="Crypto"
 # X_ACCOUNTS_CRYPTO=VitalikButerin,cz_binance
 # X_TOPICS_CRYPTO=Bitcoin,Ethereum,DeFi,Web3
+#
+# Quote topic lists if any item contains spaces:
+# X_TOPICS_OPENAI="GPT,ChatGPT,OpenAI,Codex,gpt 5.4"
+# X_TOPICS_ANTHROPIC="Claude,Anthropic,ClaudeCode,Claude Code"
 #
 # X_ACCOUNTS_NEWS_LABEL="Tech News"
 # X_ACCOUNTS_NEWS=TechCrunch,veraborisova

--- a/plugins/x-research/skills/x-research/config/README.md
+++ b/plugins/x-research/skills/x-research/config/README.md
@@ -15,6 +15,9 @@ cp .env.example .env
 
 Edit `.env` and paste your key into `XAI_API_KEY`.
 
+Important: keep `.env` shell-compatible. If a value contains spaces, wrap the whole value in quotes.
+Some runners use `. config/.env`, and unquoted values such as `Claude Code` will be treated as commands.
+
 ## 3. Configure accounts & topics
 
 Edit `.env` to add X accounts you want to follow and topics you care about.
@@ -31,6 +34,10 @@ X_ACCOUNTS_AI=elonmusk,sama,AndrewYNg
 
 X_ACCOUNTS_CRYPTO_LABEL="Crypto"
 X_ACCOUNTS_CRYPTO=VitalikButerin,cz_binance
+
+# Quote values with spaces
+X_TOPICS_OPENAI="GPT,ChatGPT,OpenAI,Codex,gpt 5.4"
+X_TOPICS_ANTHROPIC="Claude,Anthropic,ClaudeCode,Claude Code"
 ```
 
 **Note:** `allowed_x_handles` API limit is 10 per request. Categories with >10 accounts are automatically batched.

--- a/plugins/x-research/skills/x-research/scripts/common.sh
+++ b/plugins/x-research/skills/x-research/scripts/common.sh
@@ -28,32 +28,52 @@ check_python3() {
 # --------------- Config ---------------
 
 load_config() {
+    check_python3
     if [ -f "$CONFIG_FILE" ]; then
-        # Safe .env parser: handles unquoted values with spaces
-        # Reads KEY=VALUE lines, strips optional quotes, exports via eval with quoting
-        while IFS= read -r _line || [ -n "$_line" ]; do
-            # Skip empty lines and comments
-            case "$_line" in
-                ''|\#*) continue ;;
-            esac
-            # Extract key (everything before first =)
-            _key="${_line%%=*}"
-            # Validate key: only [A-Za-z_][A-Za-z0-9_]*
-            case "$_key" in
-                *[!A-Za-z0-9_]*) continue ;;
-                [0-9]*) continue ;;
-            esac
-            # Extract value (everything after first =)
-            _val="${_line#*=}"
-            # Strip surrounding quotes if present
-            case "$_val" in
-                \"*\") _val="${_val#\"}"; _val="${_val%\"}" ;;
-                \'*\') _val="${_val#\'}"; _val="${_val%\'}" ;;
-            esac
-            # Export with safe quoting
-            eval "$_key=\"\$_val\""
-            export "$_key"
-        done < "$CONFIG_FILE"
+        _exports_file=$(mktemp "${TMPDIR:-/tmp}/xr_env.XXXXXX")
+        if ! python3 - "$CONFIG_FILE" > "$_exports_file" <<'PY'
+import pathlib
+import re
+import shlex
+import sys
+
+path = pathlib.Path(sys.argv[1])
+key_pattern = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+for lineno, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+    if not raw_line.strip() or raw_line.lstrip().startswith("#") or "=" not in raw_line:
+        continue
+
+    key, value = raw_line.split("=", 1)
+    key = key.strip()
+    if not key_pattern.fullmatch(key):
+        continue
+
+    value = value.strip()
+    quoted = False
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        value = value[1:-1]
+        quoted = True
+
+    print(f"export {key}={shlex.quote(value)}")
+
+    if not quoted and any(ch.isspace() for ch in value):
+        print(
+            f"Warning: {path.name}:{lineno} {key} contains spaces without quotes. "
+            "Quote the value to keep config/.env shell-compatible.",
+            file=sys.stderr,
+        )
+PY
+        then
+            rm -f "$_exports_file"
+            echo "Error: failed to parse $CONFIG_FILE." >&2
+            exit 1
+        fi
+        # Source a sanitized export file instead of eval'ing raw .env content.
+        # This keeps the loader tolerant of unquoted spaces and avoids executing config text.
+        # shellcheck disable=SC1090
+        . "$_exports_file"
+        rm -f "$_exports_file"
     fi
     if [ -z "$XAI_API_KEY" ]; then
         echo "Error: XAI_API_KEY not set. Copy config/.env.example to config/.env and add your key." >&2
@@ -61,7 +81,6 @@ load_config() {
     fi
     XAI_MODEL="${XAI_MODEL:-grok-4-1-fast-reasoning}"
     X_DEFAULT_CATEGORY="${X_DEFAULT_CATEGORY:-ai}"
-    check_python3
     mkdir -p "$RUNS_DIR"
 }
 

--- a/plugins/x-research/skills/x-research/scripts/tests/run.sh
+++ b/plugins/x-research/skills/x-research/scripts/tests/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+sh "$SCRIPT_DIR/test_config_loader.sh"
+
+echo "x-research tests passed"

--- a/plugins/x-research/skills/x-research/scripts/tests/test_config_loader.sh
+++ b/plugins/x-research/skills/x-research/scripts/tests/test_config_loader.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMMON_SH="$SKILL_DIR/scripts/common.sh"
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/xr_config_test.XXXXXX")
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT TERM
+
+cat > "$TMP_DIR/.env" <<'EOF'
+XAI_API_KEY=test-key
+XAI_MODEL=grok-test
+X_DEFAULT_CATEGORY=openai
+X_TOPICS_OPENAI=GPT,ChatGPT,OpenAI,Codex,gpt 5.4
+X_TOPICS_ANTHROPIC=Claude,Anthropic,ClaudeCode,Claude Code
+X_ACCOUNTS_OPENAI_LABEL="OpenAI ecosystem"
+X_ACCOUNTS_OPENAI=sama,OpenAI
+EOF
+
+# shellcheck disable=SC1090
+. "$COMMON_SH"
+
+CONFIG_FILE="$TMP_DIR/.env"
+CACHE_DIR="$TMP_DIR/cache"
+RUNS_DIR="$CACHE_DIR/runs"
+INDEX_FILE="$CACHE_DIR/index.jsonl"
+
+load_config >/dev/null
+
+[ "$XAI_API_KEY" = "test-key" ]
+[ "$XAI_MODEL" = "grok-test" ]
+[ "$X_DEFAULT_CATEGORY" = "openai" ]
+[ "$X_TOPICS_OPENAI" = "GPT,ChatGPT,OpenAI,Codex,gpt 5.4" ]
+[ "$X_TOPICS_ANTHROPIC" = "Claude,Anthropic,ClaudeCode,Claude Code" ]
+[ "$X_ACCOUNTS_OPENAI_LABEL" = "OpenAI ecosystem" ]
+[ "$X_ACCOUNTS_OPENAI" = "sama,OpenAI" ]


### PR DESCRIPTION
## What changed
- replaced the `x-research` `.env` loader with a sanitized export flow instead of shell `eval`
- documented that values containing spaces must be quoted to keep `config/.env` shell-compatible
- added a regression test for topic values such as `Claude Code` and `gpt 5.4`

## Why
The failure was caused by shell-incompatible `.env` values, not by the X API itself. Some runners source `config/.env` directly, and lines like `X_TOPICS_ANTHROPIC=...,Claude Code` make the shell try to execute `Code` as a command. That is why the reproduced error was `config/.env: line 31: Code: command not found`.

## Impact
- `x-research` now loads config without executing raw `.env` content
- template and docs steer users toward shell-safe config values
- local secrets remain outside git: `config/.env` is still ignored and was not staged

## Validation
- `sh plugins/x-research/skills/x-research/scripts/tests/run.sh`
- `cd plugins/x-research/skills/x-research && bash -lc '. config/.env'`
- `bash plugins/x-research/skills/x-research/scripts/search.sh --query 'OpenAI Pro tier usage limits' --period week --limit 3`
- `git diff --cached -U0 | rg -n 'xai-[A-Za-z0-9]{20,}|Authorization: Bearer|API_KEY=.*[A-Za-z0-9]{20,}'`
