### PR TITLE
[codex] Add GPT support to fal-ai-image skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,7 +45,7 @@
     },
     {
       "name": "fal-ai-image",
-      "description": "Generate images using fal.ai nano-banana model",
+      "description": "Generate and edit images via fal.ai Nano Banana Pro or OpenAI GPT Image 2",
       "source": "./plugins/fal-ai-image",
       "category": "productivity"
     },

--- a/README.md
+++ b/README.md
@@ -214,11 +214,13 @@ SSH подключение к удалённым серверам с agent forwa
 
 ### [fal-ai-image](plugins/fal-ai-image/skills/fal-ai-image)
 
-Генерация изображений через fal.ai nano-banana-pro (Gemini 3 Pro Image).
+Генерация изображений через fal.ai с переключением модели из конфига.
 
-- Генерация из текстового промпта (text-to-image)
-- Редактирование с референсными изображениями (image-to-image)
-- Поддержка разрешений 1K / 2K / 4K
+- Google Nano Banana Pro по умолчанию для обратной совместимости
+- OpenAI GPT Image 2 через тот же `FAL_KEY`
+- Генерация из текста и редактирование по референсам
+- Совместимость старых `--aspect-ratio` / `--resolution` сценариев после переключения на GPT
+- Разовый форс модели через `--model gpt|openai|nano-banana|google|gemini`
 
 **Триггеры (RU):**
 - "сгенерируй изображение"

--- a/plugins/fal-ai-image/.claude-plugin/plugin.json
+++ b/plugins/fal-ai-image/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fal-ai-image",
-  "version": "1.1.0",
-  "description": "Generate images using fal.ai nano-banana model",
+  "version": "1.2.0",
+  "description": "Generate and edit images via fal.ai Nano Banana Pro or OpenAI GPT Image 2",
   "author": {
     "name": "Polyakov"
   }

--- a/plugins/fal-ai-image/skills/fal-ai-image/SKILL.md
+++ b/plugins/fal-ai-image/skills/fal-ai-image/SKILL.md
@@ -1,107 +1,146 @@
 ---
 name: fal-ai-image
-description: "Generate/edit images via fal.ai nano-banana-pro. Supports reference images (Edit mode) and text rendering in any language including Cyrillic. ALWAYS read SKILL.md before first use."
+description: "Generate/edit images via fal.ai. Supports Google Nano Banana Pro and OpenAI GPT Image 2 selected from config/.env. Supports reference images and strong text rendering. ALWAYS read SKILL.md before first use."
 ---
 
 # fal-ai-image
 
-Generate images via fal.ai nano-banana-pro (Gemini 3 Pro Image).
-Best for: infographics, text rendering, complex compositions.
+Generate images via fal.ai. The skill now supports two fal-hosted models:
+
+- **Google Nano Banana Pro** (`fal-ai/nano-banana-pro`) — default, backward-compatible
+- **OpenAI GPT Image 2** (`openai/gpt-image-2`) — enabled from `config/.env`
+
+Synonyms the agent should treat as equivalent:
+
+- `gpt` = `openai` = GPT Image 2
+- `nano banana` = `google` = `gemini` = Nano Banana Pro
+
+Best for: infographics, text rendering, banners, photo edits, reference-based compositions.
 
 ## STOP — Read Before Acting
 
-- **DO NOT** use Pillow, ImageMagick, or any post-processing for text/logo overlay — this model renders text natively, including Cyrillic and CJK
-- **DO NOT** use Generate mode when user provides reference images — use **Edit mode**
-- **DO NOT** launch general-purpose subagents — use `Task` with `subagent_type: "Bash"` and `model: "haiku"`
+- **DO NOT** use Pillow, ImageMagick, or post-processing for text/logo overlay unless the user explicitly asked for that workflow
+- **DO NOT** use Generate mode when the user provided reference images — use **Edit mode**
+- **DO NOT** assume GPT is active — check `config/README.md` logic; if no selector is configured, the skill stays on Nano Banana
+- **DO NOT** guess provider-specific params — Nano Banana and GPT Image 2 use different schemas
+- **DO** pass `--model ...` when the user explicitly asks for a specific model/provider or asks to compare providers
 - **DO NOT** skip uploading local files — run `upload.sh` first to get URLs for `edit.sh`
-- **DO NOT** guess script parameters — check the tables below
 
 ## Quick Start Decision
 
+```text
+Reference images provided?  -> Edit mode   (upload.sh -> edit.sh)
+Text-only generation?       -> Generate mode (generate.sh)
+
+Model comes from config/.env:
+  no selector set           -> Nano Banana Pro
+  FAL_IMAGE_PROVIDER=openai -> GPT Image 2
+  FAL_IMAGE_MODEL=...       -> exact override
 ```
-User gave reference images?  → Edit mode  (upload.sh → edit.sh)
-User wants text-only gen?    → Generate mode (generate.sh)
-Multiple images needed?      → Parallel Bash/haiku subagents
-```
-
-## Model Capabilities
-
-- Excellent text rendering (Latin, Cyrillic, CJK) — no post-processing needed
-- Composes logos, product photos, and text into banners in a single pass
-- Understands layout instructions ("left side text, right side product photo")
-- Handles complex infographics, charts, and diagrams
-- Edit mode blends reference images naturally with prompt guidance
-
-## Compatibility
-
-Scripts are POSIX sh compatible — work in cloud sandboxes (`/bin/sh`) and locally (`bash`).
-No bashisms: `[[ ]]`, `${BASH_SOURCE}`, `source` etc. are NOT used.
 
 ## Config
 
-Requires `FAL_KEY` in `config/.env` or environment.
-Get key: https://fal.ai/dashboard/keys
+Requires `FAL_KEY` in `config/.env` or the environment.
 
-## Two Modes
+Model selection:
 
-### 1. Generate (text-to-image)
-Create images from text prompt only.
-Script: `scripts/generate.sh`
+1. `--model` — one-off override for the current command
+2. `FAL_IMAGE_MODEL` — exact override in config
+3. `FAL_IMAGE_PROVIDER` — `google` or `openai`
+4. nothing set — default to Nano Banana Pro
 
-### 2. Edit (image-to-image)
-Create images using reference images (up to 14).
-Script: `scripts/edit.sh`
+Use `--model` whenever the user explicitly says things like:
+
+- "сделай через GPT"
+- "используй OpenAI"
+- "сделай через Google / Gemini / Nano Banana"
+- "какие тут есть провайдеры?"
+
+Answer that the skill supports two choices and map the command like this:
+
+- `--model gpt` for OpenAI GPT Image 2
+- `--model gemini` or `--model nano-banana` for Nano Banana
+
+OpenAI quality default:
+
+- `FAL_IMAGE_OPENAI_QUALITY=medium` unless overridden with `--quality`
+- this skill intentionally uses `medium` as the default for GPT to avoid expensive exploratory runs
+
+Full setup and troubleshooting: [config/README.md](config/README.md).
+
+Read references only when needed:
+
+- [references/MODELS.md](references/MODELS.md) — selector precedence, aliases, cost heuristics
+- [references/EDITING.md](references/EDITING.md) — generate vs edit, `mask_url`, inpainting behavior
+
+## Model Notes
+
+### Nano Banana Pro
+
+Strengths:
+
+- lower-friction default for existing installs
+- strong text rendering, including Cyrillic
+- good at infographics, banners, and mixed text/image layouts
+- supports `--web-search` in generate mode
+
+Main params:
+
+- `--aspect-ratio`
+- `--resolution`
+- `--web-search` (generate only)
+
+### OpenAI GPT Image 2
+
+Strengths:
+
+- stronger prompt adherence and fine-grained edits
+- better photorealism and product-style renders
+- native `quality` control
+- uses the same `FAL_KEY` through fal, no separate OpenAI key
+- current fal pricing is size/quality-dependent; a rough high-quality mental model is about `$0.18` per image, but check the live model page before quoting an exact number
+
+Main params:
+
+- `--image-size`
+- `--quality`
+
+Compatibility layer:
+
+- if `--image-size` is omitted, the scripts derive a valid OpenAI `image_size` from `--aspect-ratio` + `--resolution`
+- this lets old prompts continue working after the provider switch in config
 
 ## Workflow
 
-**IMPORTANT**: Run generation via Task tool with Haiku subagent to avoid blocking main context.
+### Generate mode
 
-### For Generate mode:
+1. Decide model from config
+2. Clarify missing params only if needed:
+   - Nano Banana: aspect ratio, resolution
+   - GPT Image 2: image size and quality
+3. Propose save path based on project structure
+4. Run `generate.sh`
+5. Parse result JSON, report URL and local files if downloaded
 
-1. **Clarify params** (if not specified):
-   - Aspect ratio: `1:1`, `16:9`, `9:16`, `4:3`, etc.
-   - Resolution: `1K` (default), `2K`, `4K`
+### Edit mode
 
-2. **Propose save path** based on project structure:
-   - Check for `./images/`, `./assets/`, `./static/`
-   - Suggest: "Save to `./images/infographic_coffee.png`?"
-
-3. **Show price & confirm**:
-   ```
-   Cost: $0.15/image (4K: $0.30)
-   Confirm? (yes/no)
-   ```
-
-4. **Launch subagent**:
-   ```
-   Task tool:
-   - subagent_type: "Bash"
-   - model: "haiku"
-   - run_in_background: true
-   - prompt: Run generate.sh with params
-   ```
-
-5. **Report result**: Parse JSON output, show image URL, read saved file.
-
-### For Edit mode:
-
-1. **Get reference images**:
-   - If URLs provided → use directly
-   - If local files → run `upload.sh` first to get URLs
-
-2. **Clarify prompt**: What to do with references?
-
-3. **Show price & confirm**: Same as generate
-
-4. **Launch subagent** with `edit.sh`
-
-5. **Report result**
+1. Get reference images:
+   - URL already available -> use directly
+   - local file -> `upload.sh`
+2. Decide model from config
+3. Clarify edit intent
+4. Run `edit.sh`
+5. Parse result JSON, report URL and local files if downloaded
 
 ## Scripts
 
 ### generate.sh
+
+Nano Banana example:
+
 ```bash
 sh scripts/generate.sh \
+  --model "gemini" \
   --prompt "infographic about coffee brewing" \
   --aspect-ratio "9:16" \
   --resolution "1K" \
@@ -109,19 +148,49 @@ sh scripts/generate.sh \
   --filename "coffee_infographic"
 ```
 
-| Param | Required | Default | Values |
-|-------|----------|---------|--------|
-| `--prompt` | yes | - | text |
-| `--aspect-ratio` | no | 1:1 | 21:9, 16:9, 3:2, 4:3, 5:4, 1:1, 4:5, 3:4, 2:3, 9:16 |
-| `--resolution` | no | 1K | 1K, 2K, 4K |
+GPT Image 2 example:
+
+```bash
+sh scripts/generate.sh \
+  --model "gpt" \
+  --prompt "realistic product hero shot with sharp packaging text" \
+  --image-size "landscape_4_3" \
+  --quality "medium" \
+  --output-dir "./images" \
+  --filename "product_hero"
+```
+
+Compatibility example for GPT:
+
+```bash
+sh scripts/generate.sh \
+  --model "openai" \
+  --prompt "editorial portrait, window light, magazine cover layout" \
+  --aspect-ratio "4:3" \
+  --resolution "2K"
+```
+
+| Param | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `--prompt` | yes | - | text prompt |
+| `--model` | no | config / Nano Banana fallback | `nano-banana`, `google`, `gemini`, `gpt`, `openai`, or exact endpoint |
+| `--aspect-ratio` | no | `1:1` | Nano native; for GPT used only when `--image-size` is omitted |
+| `--resolution` | no | `1K` | Nano native; for GPT used only when `--image-size` is omitted |
+| `--image-size` | no | derived from ratio/resolution | GPT only; preset (`landscape_4_3`) or `WIDTHxHEIGHT` |
+| `--quality` | no | `medium` via config | GPT only; `low`, `medium`, `high` |
 | `--num-images` | no | 1 | 1-4 |
-| `--output-dir` | no | - | path |
-| `--filename` | no | generated | base name |
-| `--web-search` | no | false | flag |
+| `--output-format` | no | `png` | `jpeg`, `png`, `webp` |
+| `--output-dir` | no | - | local path |
+| `--filename` | no | `generated` | base filename |
+| `--web-search` | no | false | Nano only; ignored for GPT |
 
 ### edit.sh
+
+Nano Banana example:
+
 ```bash
 sh scripts/edit.sh \
+  --model "gemini" \
   --prompt "combine these into a collage" \
   --image-urls "https://example.com/img1.png,https://example.com/img2.png" \
   --aspect-ratio "16:9" \
@@ -129,48 +198,55 @@ sh scripts/edit.sh \
   --filename "collage"
 ```
 
-| Param | Required | Default | Values |
-|-------|----------|---------|--------|
-| `--prompt` | yes | - | text |
-| `--image-urls` | yes | - | comma-separated URLs (max 14) |
-| `--aspect-ratio` | no | auto | auto, 1:1, 16:9, etc. |
-| `--resolution` | no | 1K | 1K, 2K, 4K |
-| `--num-images` | no | 1 | 1-4 variations |
-| `--output-dir` | no | - | path |
-| `--filename` | no | edited | base name |
+GPT Image 2 example:
 
-### upload.sh (for local files)
 ```bash
-# Get URL for local file
+sh scripts/edit.sh \
+  --model "gpt" \
+  --prompt "make this product shot look like a premium studio campaign" \
+  --image-urls "https://example.com/source.png" \
+  --mask-url "https://example.com/mask.png" \
+  --image-size "auto" \
+  --quality "medium" \
+  --output-dir "./images" \
+  --filename "studio_edit"
+```
+
+| Param | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `--prompt` | yes | - | edit instruction |
+| `--image-urls` | yes | - | comma-separated URLs |
+| `--model` | no | config / Nano Banana fallback | `nano-banana`, `google`, `gemini`, `gpt`, `openai`, or exact endpoint |
+| `--mask-url` | no | - | GPT edit only; optional mask for targeted edits |
+| `--aspect-ratio` | no | `auto` | Nano native; for GPT used only when `--image-size` is omitted |
+| `--resolution` | no | `1K` | Nano native; for GPT used only when `--image-size` is omitted |
+| `--image-size` | no | derived from ratio/resolution / `auto` | GPT only |
+| `--quality` | no | `medium` via config | GPT only |
+| `--num-images` | no | 1 | 1-4 |
+| `--output-format` | no | `png` | `jpeg`, `png`, `webp` |
+| `--output-dir` | no | - | local path |
+| `--filename` | no | `edited` | base filename |
+
+### upload.sh
+
+```bash
+# Get hosted URL for local file
 URL=$(sh scripts/upload.sh --file /path/to/image.png)
 
-# Or get base64 data URI (for small files)
+# Get base64 data URI for manual API work
 URI=$(sh scripts/upload.sh --file /path/to/image.png --base64)
 ```
 
-## Parallel Generation
+## Cost Guidance
 
-For multiple images — launch several subagents in parallel:
+- **Nano Banana Pro** is the cheaper and safer default for quick iterations
+- **GPT Image 2** cost depends heavily on `quality` and `image_size`
+- this skill defaults GPT to `medium` quality to reduce surprise spend
 
-```
-Task 1: generate "cat in space" → cat_space.png
-Task 2: generate "dog on moon" → dog_moon.png
-Task 3: generate "bird in ocean" → bird_ocean.png
-```
-
-Each runs independently via Haiku, results collected when done.
-
-## Pricing
-
-- Generate: **$0.15**/image
-- Edit: **$0.15**/edit
-- 4K resolution: **$0.30** (2x)
-- Web search: **+$0.015**
-
-Formula: `price = num_images * (resolution == "4K" ? 0.30 : 0.15) + (web_search ? 0.015 : 0)`
+For current pricing, check fal's model pages in [config/README.md](config/README.md).
 
 ## Notes
 
-- URLs expire in ~1 hour — save locally if needed
-- Uploaded files stored 7 days on fal.ai, then auto-deleted
-- Model excels at text rendering and infographics
+- result URLs expire in roughly one hour — download locally if you need persistence
+- uploaded files on fal storage are temporary
+- `edit.sh` now polls the same `/edit` queue endpoints documented by fal

--- a/plugins/fal-ai-image/skills/fal-ai-image/config/.env.example
+++ b/plugins/fal-ai-image/skills/fal-ai-image/config/.env.example
@@ -1,3 +1,24 @@
-# fal.ai API key
+# fal.ai API key (required for both Nano Banana Pro and GPT Image 2 on fal)
 # Get yours at: https://fal.ai/dashboard/keys
 FAL_KEY=your_fal_api_key_here
+
+# Optional selector. If neither variable is set, the skill stays on Nano Banana
+# for backward compatibility with older installs.
+#
+# For one-off runs, prefer the CLI flag:
+#   --model gpt
+#   --model openai
+#   --model nano-banana
+#   --model google
+#   --model gemini
+#
+# Human-friendly selector:
+# FAL_IMAGE_PROVIDER=google   # google | openai
+#
+# Exact model override (wins over FAL_IMAGE_PROVIDER if both are set):
+# FAL_IMAGE_MODEL=fal-ai/nano-banana-pro
+# FAL_IMAGE_MODEL=openai/gpt-image-2
+
+# Optional OpenAI-specific default. The fal API defaults to high quality, but
+# this skill uses medium unless you override it here or via --quality.
+# FAL_IMAGE_OPENAI_QUALITY=medium   # low | medium | high

--- a/plugins/fal-ai-image/skills/fal-ai-image/config/README.md
+++ b/plugins/fal-ai-image/skills/fal-ai-image/config/README.md
@@ -1,12 +1,202 @@
 # Configuration
 
-## Setup
+The skill supports **two fal-hosted image models** behind the same `FAL_KEY`:
 
-1. Get API key at https://fal.ai/dashboard/keys
+| Selector | Resolved model | Best for |
+|----------|----------------|----------|
+| default / `google` | `fal-ai/nano-banana-pro` | backward-compatible default, infographics, lower cost |
+| `openai` | `openai/gpt-image-2` | stronger prompt adherence, photorealism, detailed edits |
+
+No separate OpenAI key is required when you use the fal-hosted GPT model.
+
+## One-off override from CLI
+
+Both `generate.sh` and `edit.sh` support:
+
+```bash
+--model VALUE
+```
+
+Supported aliases:
+
+| `--model` value | Resolved model |
+|-----------------|----------------|
+| `nano-banana`, `google`, `gemini` | `fal-ai/nano-banana-pro` |
+| `gpt`, `openai` | `openai/gpt-image-2` |
+| exact endpoint IDs | same endpoint |
+
+Examples:
+
+```bash
+sh scripts/generate.sh --model gpt --prompt "studio product render"
+sh scripts/generate.sh --model gemini --prompt "text-heavy infographic"
+sh scripts/edit.sh --model openai --image-urls "$URL" --prompt "premium ad retouch"
+```
+
+Use this when the user explicitly asks for a specific model or asks which options are available.
+
+`edit.sh` also supports:
+
+```bash
+--mask-url URL
+```
+
+This is passed through to `openai/gpt-image-2/edit` and is useful when you want to constrain the edit to a specific region. Nano Banana does not support this flag in the current skill.
+
+## Quick start
+
+1. Get an API key at https://fal.ai/dashboard/keys
 2. Copy `.env.example` to `.env`
-3. Set your `FAL_KEY`
+3. Set `FAL_KEY`
 
-## Priority
+Minimal config keeps the old behavior:
 
-1. `config/.env` file
-2. `FAL_KEY` environment variable
+```env
+FAL_KEY=your_fal_api_key_here
+```
+
+This resolves to **Nano Banana Pro** automatically.
+
+## Switch to OpenAI GPT Image 2
+
+Use the human-friendly selector:
+
+```env
+FAL_KEY=your_fal_api_key_here
+FAL_IMAGE_PROVIDER=openai
+FAL_IMAGE_OPENAI_QUALITY=medium
+```
+
+Or pin the exact fal model ID:
+
+```env
+FAL_KEY=your_fal_api_key_here
+FAL_IMAGE_MODEL=openai/gpt-image-2
+FAL_IMAGE_OPENAI_QUALITY=medium
+```
+
+## Selector precedence
+
+Selection in `scripts/common.sh` is intentionally simple:
+
+1. `--model` — one-off CLI override
+2. `FAL_IMAGE_MODEL` — exact model override in config
+3. `FAL_IMAGE_PROVIDER` — `google` or `openai`
+4. Nothing set — fallback to `fal-ai/nano-banana-pro`
+
+That means older installs with only `FAL_KEY` keep working without any changes, while a single run can still force GPT or Nano Banana.
+
+## Parameter mapping by model
+
+### Nano Banana Pro
+
+Native knobs:
+
+- `--aspect-ratio`
+- `--resolution`
+- `--web-search` (generate only)
+
+### OpenAI GPT Image 2
+
+Native knobs:
+
+- `--image-size`
+- `--quality`
+- `--mask-url` in `edit.sh`
+
+Supported `--image-size` forms:
+
+- preset: `square_hd`, `square`, `portrait_4_3`, `portrait_16_9`, `landscape_4_3`, `landscape_16_9`
+- custom size: `WIDTHxHEIGHT` (for example `1536x1024`)
+- `auto` in `edit.sh`
+
+Compatibility layer:
+
+- if `--image-size` is omitted, the scripts derive a valid OpenAI `image_size` from `--aspect-ratio` + `--resolution`
+- this keeps the old CLI shape usable after switching the provider in config
+
+## Quality default for OpenAI
+
+fal's GPT Image 2 schema defaults `quality` to `high`, but this skill uses:
+
+```env
+FAL_IMAGE_OPENAI_QUALITY=medium
+```
+
+as the default unless you override it via `--quality`.
+
+Reason: `high` can make exploratory runs noticeably more expensive than Nano Banana. `medium` is a safer default for iteration; use `--quality high` for final renders.
+
+As of April 22, 2026, fal's GPT Image 2 playground shows common high-quality renders landing roughly around `$0.15-$0.22` per image depending on size, so the "about $0.18" rule of thumb is reasonable for user guidance. Verify current prices on the model page before promising a number: [GPT Image 2 pricing](https://fal.ai/models/openai/gpt-image-2/playground).
+
+## Examples
+
+### Default Nano Banana
+
+```bash
+sh scripts/generate.sh \
+  --prompt "poster about coffee brewing" \
+  --aspect-ratio "9:16" \
+  --resolution "1K"
+```
+
+### OpenAI GPT Image 2 with explicit preset size
+
+```bash
+sh scripts/generate.sh \
+  --model "gpt" \
+  --prompt "realistic product hero shot, clean label typography" \
+  --image-size "landscape_4_3" \
+  --quality "medium"
+```
+
+### OpenAI GPT Image 2 while keeping old flags
+
+```bash
+sh scripts/generate.sh \
+  --model "openai" \
+  --prompt "editorial-style fashion photo" \
+  --aspect-ratio "4:3" \
+  --resolution "2K"
+```
+
+The script will derive a valid `image_size` object for OpenAI automatically.
+
+## Troubleshooting
+
+### `FAL_KEY not found`
+
+Set `FAL_KEY` in `config/.env` or the shell environment.
+
+### `Unsupported FAL_IMAGE_PROVIDER`
+
+Use only:
+
+```env
+FAL_IMAGE_PROVIDER=google
+FAL_IMAGE_PROVIDER=openai
+```
+
+### `Unsupported FAL_IMAGE_MODEL`
+
+Use only:
+
+```env
+FAL_IMAGE_MODEL=fal-ai/nano-banana-pro
+FAL_IMAGE_MODEL=openai/gpt-image-2
+```
+
+### `OpenAI image_size width and height must be multiples of 16`
+
+When you pass custom `--image-size`, use dimensions like:
+
+- `1024x1024`
+- `1536x1024`
+- `1920x1088`
+
+## References
+
+- Nano Banana Pro API: https://fal.ai/models/fal-ai/nano-banana-pro/api
+- Nano Banana Pro edit API: https://fal.ai/models/fal-ai/nano-banana-pro/edit/api
+- GPT Image 2 API: https://fal.ai/models/openai/gpt-image-2/api
+- GPT Image 2 edit API: https://fal.ai/models/openai/gpt-image-2/edit/api

--- a/plugins/fal-ai-image/skills/fal-ai-image/references/EDITING.md
+++ b/plugins/fal-ai-image/skills/fal-ai-image/references/EDITING.md
@@ -1,0 +1,79 @@
+# Editing Workflows
+
+## Generate vs Edit
+
+Use `generate.sh` when the user wants a brand new image from text.
+
+Use `edit.sh` when at least one source image matters:
+
+- preserve composition from a source
+- restyle an existing picture
+- replace or add objects
+- modify only one area of an image
+
+## Reference images
+
+`edit.sh` accepts:
+
+- public URLs directly in `--image-urls`
+- local files after uploading through `scripts/upload.sh`
+
+When several input images are passed to GPT edit, the mask applies to the **first** image.
+
+## `mask_url`
+
+`mask_url` is currently supported only for `openai/gpt-image-2/edit`.
+
+Purpose:
+
+- tells the model which region should be edited
+- keeps the rest of the image more stable
+- is best for inpainting-style changes such as swapping one object, changing text in one block, replacing a sign, retouching a face region, etc.
+
+Important nuance from OpenAI's image docs:
+
+- with GPT Image, the mask is **guidance**, not a perfect hard boundary
+- the model usually follows the masked region, but may bleed slightly outside it if the prompt implies broader changes
+
+## Mask requirements
+
+Practical requirements for reliable results:
+
+- mask and source image should have the same size
+- mask should have an alpha channel
+- transparent area should represent the region to replace
+- keep the prompt tightly scoped to the masked area when you want localized edits
+
+## When to use a mask
+
+Use a mask when the user says something like:
+
+- "замени только вывеску"
+- "поменяй текст только в этом блоке"
+- "убери объект справа, остальное не трогай"
+- "сделай ретушь только лица"
+
+Do **not** bother with `mask_url` when the user wants a broad restyle of the whole image. In that case plain `edit.sh` with references is simpler.
+
+## Prompting tips for masked edits
+
+- explicitly mention what must stay unchanged
+- name the target area in the prompt
+- avoid global style rewrites unless you actually want spillover outside the mask
+
+Example:
+
+```bash
+sh scripts/edit.sh \
+  --model gpt \
+  --image-urls "https://example.com/base.png" \
+  --mask-url "https://example.com/mask.png" \
+  --image-size auto \
+  --quality medium \
+  --prompt "Replace only the masked area with a matte red ceramic mug. Keep the rest of the poster unchanged."
+```
+
+References:
+
+- fal GPT edit API: https://fal.ai/models/openai/gpt-image-2/edit/api
+- OpenAI image generation guide: https://platform.openai.com/docs/guides/image-generation

--- a/plugins/fal-ai-image/skills/fal-ai-image/references/MODELS.md
+++ b/plugins/fal-ai-image/skills/fal-ai-image/references/MODELS.md
@@ -1,0 +1,48 @@
+# Model Selection
+
+The skill supports two fal-hosted image backends behind the same `FAL_KEY`:
+
+| Alias family | Resolved endpoint | Best for |
+|--------------|-------------------|----------|
+| `nano-banana`, `google`, `gemini` | `fal-ai/nano-banana-pro` | cheaper default runs, infographics, strong text rendering |
+| `gpt`, `openai` | `openai/gpt-image-2` | stronger prompt adherence, photorealism, precise editing |
+
+## Selection precedence
+
+The scripts resolve the active model in this order:
+
+1. CLI `--model`
+2. `FAL_IMAGE_MODEL` in `config/.env`
+3. `FAL_IMAGE_PROVIDER` in `config/.env`
+4. fallback to `fal-ai/nano-banana-pro`
+
+This means:
+
+- old installs with only `FAL_KEY` still work
+- a single request can explicitly force GPT or Nano Banana
+- the agent should use `--model` when the user explicitly asks for a provider/model
+
+## Agent mapping rules
+
+Treat these phrases as equivalent:
+
+- `GPT`, `OpenAI`, `ChatGPT Images`, `GPT Image` -> `--model gpt`
+- `Nano Banana`, `Google`, `Gemini` -> `--model gemini`
+
+If the user does **not** mention the model explicitly, let the config decide.
+
+## Cost guidance
+
+Nano Banana is the safer default for exploratory runs.
+
+GPT Image 2 cost depends on:
+
+- `quality`
+- `image_size`
+- edit vs generate complexity
+
+As of April 22, 2026, fal's GPT Image 2 playground shows common high-quality outputs roughly in the `$0.15-$0.22` range depending on size. For rough planning, "about `$0.18`" is acceptable, but do not promise a fixed price without checking the live model page first.
+
+Reference:
+
+- https://fal.ai/models/openai/gpt-image-2/playground

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/common.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/common.sh
@@ -1,0 +1,456 @@
+#!/bin/sh
+# Common helpers for fal-ai-image skill.
+# POSIX sh compatible — no bashisms.
+
+if [ -z "${FAL_AI_IMAGE_SCRIPT_DIR:-}" ]; then
+    FAL_AI_IMAGE_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+if [ -z "${FAL_AI_IMAGE_SKILL_DIR:-}" ]; then
+    FAL_AI_IMAGE_SKILL_DIR="$(cd "$FAL_AI_IMAGE_SCRIPT_DIR/.." && pwd)"
+fi
+FAL_AI_IMAGE_CONFIG_FILE="${FAL_AI_IMAGE_CONFIG_FILE:-$FAL_AI_IMAGE_SKILL_DIR/config/.env}"
+
+FAL_IMAGE_GOOGLE_MODEL="fal-ai/nano-banana-pro"
+FAL_IMAGE_OPENAI_MODEL="openai/gpt-image-2"
+
+FAL_IMAGE_PROVIDER_RESOLVED=""
+FAL_IMAGE_MODEL_RESOLVED=""
+FAL_IMAGE_SELECTION_SOURCE=""
+FAL_IMAGE_OPENAI_QUALITY_RESOLVED=""
+
+die() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+json_quote() {
+    if command -v python3 >/dev/null 2>&1; then
+        _jq_value="$1" python3 - <<'PYEOF'
+import json
+import os
+print(json.dumps(os.environ["_jq_value"], ensure_ascii=False))
+PYEOF
+        return 0
+    fi
+
+    printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+}
+
+normalize_provider() {
+    _provider=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+
+    case "$_provider" in
+        ""|google|gemini|nano|nano-banana|nano-banana-pro)
+            printf 'google\n'
+            ;;
+        openai|gpt|gpt-image-2)
+            printf 'openai\n'
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+normalize_model() {
+    _model=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+
+    case "$_model" in
+        fal-ai/nano-banana-pro|fal-ai/nano-banana-pro/edit|nano-banana|nano-banana-pro|nano|google|gemini)
+            printf '%s\n' "$FAL_IMAGE_GOOGLE_MODEL"
+            ;;
+        openai/gpt-image-2|openai/gpt-image-2/edit|gpt|gpt-image-2|openai)
+            printf '%s\n' "$FAL_IMAGE_OPENAI_MODEL"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+provider_for_model() {
+    case "$1" in
+        "$FAL_IMAGE_OPENAI_MODEL")
+            printf 'openai\n'
+            ;;
+        *)
+            printf 'google\n'
+            ;;
+    esac
+}
+
+validate_openai_quality() {
+    case "$1" in
+        low|medium|high)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+load_config() {
+    _cli_model_override="${1:-}"
+
+    if [ -f "$FAL_AI_IMAGE_CONFIG_FILE" ]; then
+        # shellcheck disable=SC1090
+        . "$FAL_AI_IMAGE_CONFIG_FILE"
+    fi
+
+    if [ -z "${FAL_KEY:-}" ]; then
+        die "FAL_KEY not found. Set it in config/.env or the shell environment."
+    fi
+
+    if [ -n "$_cli_model_override" ]; then
+        FAL_IMAGE_MODEL_RESOLVED=$(normalize_model "$_cli_model_override") || \
+            die "Unsupported --model '$_cli_model_override'. Use nano-banana, google, gemini, gpt, openai, '$FAL_IMAGE_GOOGLE_MODEL', or '$FAL_IMAGE_OPENAI_MODEL'."
+        FAL_IMAGE_PROVIDER_RESOLVED=$(provider_for_model "$FAL_IMAGE_MODEL_RESOLVED")
+        FAL_IMAGE_SELECTION_SOURCE="cli override"
+    elif [ -n "${FAL_IMAGE_MODEL:-}" ]; then
+        FAL_IMAGE_MODEL_RESOLVED=$(normalize_model "$FAL_IMAGE_MODEL") || \
+            die "Unsupported FAL_IMAGE_MODEL='$FAL_IMAGE_MODEL'. Use '$FAL_IMAGE_GOOGLE_MODEL' or '$FAL_IMAGE_OPENAI_MODEL'."
+        FAL_IMAGE_PROVIDER_RESOLVED=$(provider_for_model "$FAL_IMAGE_MODEL_RESOLVED")
+        FAL_IMAGE_SELECTION_SOURCE="explicit model"
+    elif [ -n "${FAL_IMAGE_PROVIDER:-}" ]; then
+        FAL_IMAGE_PROVIDER_RESOLVED=$(normalize_provider "$FAL_IMAGE_PROVIDER") || \
+            die "Unsupported FAL_IMAGE_PROVIDER='$FAL_IMAGE_PROVIDER'. Use 'google' or 'openai'."
+        case "$FAL_IMAGE_PROVIDER_RESOLVED" in
+            google) FAL_IMAGE_MODEL_RESOLVED="$FAL_IMAGE_GOOGLE_MODEL" ;;
+            openai) FAL_IMAGE_MODEL_RESOLVED="$FAL_IMAGE_OPENAI_MODEL" ;;
+        esac
+        FAL_IMAGE_SELECTION_SOURCE="provider alias"
+    else
+        FAL_IMAGE_PROVIDER_RESOLVED="google"
+        FAL_IMAGE_MODEL_RESOLVED="$FAL_IMAGE_GOOGLE_MODEL"
+        FAL_IMAGE_SELECTION_SOURCE="backward-compatible default"
+    fi
+
+    FAL_IMAGE_OPENAI_QUALITY_RESOLVED="${FAL_IMAGE_OPENAI_QUALITY:-medium}"
+    validate_openai_quality "$FAL_IMAGE_OPENAI_QUALITY_RESOLVED" || \
+        die "Unsupported FAL_IMAGE_OPENAI_QUALITY='$FAL_IMAGE_OPENAI_QUALITY_RESOLVED'. Use low, medium, or high."
+
+    export FAL_IMAGE_PROVIDER_RESOLVED FAL_IMAGE_MODEL_RESOLVED
+    export FAL_IMAGE_SELECTION_SOURCE FAL_IMAGE_OPENAI_QUALITY_RESOLVED
+}
+
+model_queue_name() {
+    _mode="$1"
+
+    case "$_mode" in
+        generate|"")
+            printf '%s\n' "$FAL_IMAGE_MODEL_RESOLVED"
+            ;;
+        edit)
+            printf '%s/edit\n' "$FAL_IMAGE_MODEL_RESOLVED"
+            ;;
+        *)
+            die "Unsupported mode '$_mode'"
+            ;;
+    esac
+}
+
+queue_api_base() {
+    printf 'https://queue.fal.run/%s\n' "$(model_queue_name "$1")"
+}
+
+request_api_base() {
+    printf 'https://queue.fal.run/%s\n' "$FAL_IMAGE_MODEL_RESOLVED"
+}
+
+json_array_from_csv() {
+    if command -v python3 >/dev/null 2>&1; then
+        _csv_items="$1" python3 - <<'PYEOF'
+import json
+import os
+import sys
+
+items = [item.strip() for item in os.environ["_csv_items"].split(",") if item.strip()]
+if not items:
+    sys.exit(1)
+print(json.dumps(items, ensure_ascii=False, separators=(",", ":")))
+PYEOF
+        return 0
+    fi
+
+    _csv_items="$1"
+    _json="["
+    _first="true"
+    OLD_IFS=$IFS
+    IFS=','
+    set -- $_csv_items
+    IFS=$OLD_IFS
+    for _item in "$@"; do
+        _trimmed=$(printf '%s' "$_item" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+        [ -n "$_trimmed" ] || continue
+        _quoted=$(json_quote "$_trimmed")
+        if [ "$_first" = "true" ]; then
+            _json="$_json$_quoted"
+            _first="false"
+        else
+            _json="$_json,$_quoted"
+        fi
+    done
+    _json="$_json]"
+
+    if [ "$_json" = "[]" ]; then
+        return 1
+    fi
+
+    printf '%s\n' "$_json"
+}
+
+count_csv_items() {
+    if command -v python3 >/dev/null 2>&1; then
+        _csv_items="$1" python3 - <<'PYEOF'
+import os
+
+items = [item.strip() for item in os.environ["_csv_items"].split(",") if item.strip()]
+print(len(items))
+PYEOF
+        return 0
+    fi
+
+    _csv_items="$1"
+    _count=0
+    OLD_IFS=$IFS
+    IFS=','
+    set -- $_csv_items
+    IFS=$OLD_IFS
+    for _item in "$@"; do
+        _trimmed=$(printf '%s' "$_item" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+        [ -n "$_trimmed" ] || continue
+        _count=$((_count + 1))
+    done
+    printf '%s\n' "$_count"
+}
+
+openai_image_size_json() {
+    command -v python3 >/dev/null 2>&1 || die "python3 is required for OpenAI image size calculation."
+
+    _size_arg="${1:-}"
+    _aspect_ratio="${2:-1:1}"
+    _resolution="${3:-1K}"
+    _allow_auto="${4:-false}"
+
+    _size_arg="$_size_arg" \
+    _aspect_ratio="$_aspect_ratio" \
+    _resolution="$_resolution" \
+    _allow_auto="$_allow_auto" \
+    python3 - <<'PYEOF'
+import json
+import os
+import re
+import sys
+
+size_arg = os.environ["_size_arg"].strip()
+aspect_ratio = os.environ["_aspect_ratio"].strip()
+resolution = os.environ["_resolution"].strip() or "1K"
+allow_auto = os.environ["_allow_auto"].strip().lower() == "true"
+
+PRESETS = {
+    "square_hd",
+    "square",
+    "portrait_4_3",
+    "portrait_16_9",
+    "landscape_4_3",
+    "landscape_16_9",
+}
+MIN_PIXELS = 655_360
+MAX_PIXELS = 8_294_400
+MAX_EDGE = 3840
+RESOLUTION_TO_EDGE = {
+    "1K": 1024,
+    "2K": 2048,
+    "4K": 3840,
+}
+
+
+def fail(message: str) -> None:
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def validate_dimensions(width: int, height: int) -> None:
+    if width % 16 != 0 or height % 16 != 0:
+        fail("OpenAI image_size width and height must be multiples of 16.")
+    if width > MAX_EDGE or height > MAX_EDGE:
+        fail(f"OpenAI image_size max edge is {MAX_EDGE}px.")
+    if width * height < MIN_PIXELS or width * height > MAX_PIXELS:
+        fail(
+            f"OpenAI image_size total pixels must be between {MIN_PIXELS} and {MAX_PIXELS}."
+        )
+    ratio = max(width / height, height / width)
+    if ratio > 3:
+        fail("OpenAI image_size aspect ratio must stay within 3:1.")
+
+
+def best_size_for_ratio(ratio_value: float, target_edge: int):
+    best = None
+    desired_height = target_edge / ratio_value if ratio_value >= 1 else target_edge
+    desired_width = target_edge if ratio_value >= 1 else target_edge * ratio_value
+
+    for width in range(16, MAX_EDGE + 1, 16):
+        height = int(round((width / ratio_value) / 16.0) * 16)
+        if height < 16 or height > MAX_EDGE:
+            continue
+        area = width * height
+        if area < MIN_PIXELS or area > MAX_PIXELS:
+            continue
+        score = abs(width - desired_width) + abs(height - desired_height) + abs((width / height) - ratio_value) * 2000
+        if best is None or score < best[0]:
+            best = (score, width, height)
+
+    for height in range(16, MAX_EDGE + 1, 16):
+        width = int(round((height * ratio_value) / 16.0) * 16)
+        if width < 16 or width > MAX_EDGE:
+            continue
+        area = width * height
+        if area < MIN_PIXELS or area > MAX_PIXELS:
+            continue
+        score = abs(width - desired_width) + abs(height - desired_height) + abs((width / height) - ratio_value) * 2000
+        if best is None or score < best[0]:
+            best = (score, width, height)
+
+    if best is None:
+        fail(f"Unable to derive a valid OpenAI image_size for aspect ratio '{aspect_ratio}' and resolution '{resolution}'.")
+
+    return best[1], best[2]
+
+
+if size_arg:
+    if size_arg in PRESETS:
+        print(json.dumps(size_arg))
+        sys.exit(0)
+    if allow_auto and size_arg == "auto":
+        print(json.dumps("auto"))
+        sys.exit(0)
+
+    match = re.match(r"^(\d+)[xX](\d+)$", size_arg)
+    if not match:
+        fail("Unsupported --image-size. Use a preset like landscape_4_3 or dimensions like 1536x1024.")
+
+    width = int(match.group(1))
+    height = int(match.group(2))
+    validate_dimensions(width, height)
+    print(json.dumps({"width": width, "height": height}, separators=(",", ":")))
+    sys.exit(0)
+
+if allow_auto and aspect_ratio == "auto":
+    print(json.dumps("auto"))
+    sys.exit(0)
+
+match = re.match(r"^(\d+):(\d+)$", aspect_ratio)
+if not match:
+    fail("Unsupported aspect ratio for OpenAI model. Use values like 1:1, 4:3, 16:9 or pass --image-size.")
+
+ratio_w = int(match.group(1))
+ratio_h = int(match.group(2))
+if ratio_w <= 0 or ratio_h <= 0:
+    fail("Aspect ratio values must be positive integers.")
+
+if resolution not in RESOLUTION_TO_EDGE:
+    fail("Unsupported resolution for OpenAI model. Use 1K, 2K, 4K or pass --image-size.")
+
+ratio_value = ratio_w / ratio_h
+target_edge = RESOLUTION_TO_EDGE[resolution]
+width, height = best_size_for_ratio(ratio_value, target_edge)
+validate_dimensions(width, height)
+print(json.dumps({"width": width, "height": height}, separators=(",", ":")))
+PYEOF
+}
+
+extract_request_id() {
+    printf '%s' "$1" | grep -oE '"request_id":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+}
+
+extract_status() {
+    printf '%s' "$1" | grep -oE '"status":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+}
+
+submit_queue_request() {
+    _api_base="$1"
+    _json_payload="$2"
+
+    curl -s -X POST "$_api_base" \
+        -H "Authorization: Key $FAL_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$_json_payload"
+}
+
+wait_for_request() {
+    _api_base="$1"
+    _request_id="$2"
+    _max_attempts="${3:-60}"
+    _attempt=0
+
+    while [ "$_attempt" -lt "$_max_attempts" ]; do
+        _status_response=$(curl -s "$_api_base/requests/$_request_id/status" \
+            -H "Authorization: Key $FAL_KEY")
+        _status=$(extract_status "$_status_response")
+
+        case "$_status" in
+            COMPLETED)
+                echo "Generation complete!"
+                echo ""
+                return 0
+                ;;
+            FAILED)
+                echo "Error: Generation failed" >&2
+                echo "$_status_response" >&2
+                return 1
+                ;;
+            IN_PROGRESS|IN_QUEUE|PENDING)
+                echo "Status: $_status..."
+                sleep 2
+                _attempt=$((_attempt + 1))
+                ;;
+            *)
+                echo "Status: ${_status:-UNKNOWN} (retrying)..."
+                sleep 2
+                _attempt=$((_attempt + 1))
+                ;;
+        esac
+    done
+
+    echo "Error: Timeout waiting for generation" >&2
+    return 1
+}
+
+fetch_queue_result() {
+    _api_base="$1"
+    _request_id="$2"
+
+    curl -s "$_api_base/requests/$_request_id" \
+        -H "Authorization: Key $FAL_KEY"
+}
+
+download_result_images() {
+    _result="$1"
+    _output_dir="$2"
+    _filename="$3"
+    _output_format="$4"
+    _num_images="$5"
+
+    [ -n "$_output_dir" ] || return 0
+
+    mkdir -p "$_output_dir"
+    _timestamp=$(date +%Y%m%d_%H%M%S)
+    _urls=$(printf '%s' "$_result" | grep -oE '"url":[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
+    _index=0
+
+    echo "Downloading images..."
+    for _url in $_urls; do
+        _suffix=""
+        [ "$_num_images" -gt 1 ] && _suffix="_$_index"
+        _output_path="$_output_dir/${_filename}_${_timestamp}${_suffix}.${_output_format}"
+
+        if curl -s -o "$_output_path" "$_url"; then
+            echo "Saved: $_output_path"
+        else
+            echo "Warning: Failed to download $_url" >&2
+        fi
+        _index=$((_index + 1))
+    done
+    echo ""
+}

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/edit.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/edit.sh
@@ -1,166 +1,115 @@
 #!/bin/sh
-# Generate images with reference images using fal.ai nano-banana-pro/edit
-# POSIX sh compatible — works in cloud sandboxes and locally
+# Edit images via fal.ai using reference images.
+# Supports Nano Banana Pro and OpenAI GPT Image 2 (selected via config/.env).
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-CONFIG_FILE="$SCRIPT_DIR/../config/.env"
-API_BASE="https://queue.fal.run/fal-ai/nano-banana-pro/edit"
-STATUS_BASE="https://queue.fal.run/fal-ai/nano-banana-pro"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/common.sh"
 
-# Load config
-if [ -f "$CONFIG_FILE" ]; then
-    # shellcheck disable=SC1090
-    . "$CONFIG_FILE"
-fi
-
-if [ -z "$FAL_KEY" ]; then
-    echo "Error: FAL_KEY not found. Set in config/.env or environment."
-    exit 1
-fi
-
-# Defaults
 PROMPT=""
 IMAGE_URLS=""
+MODEL_OVERRIDE=""
+MASK_URL=""
 ASPECT_RATIO="auto"
 RESOLUTION="1K"
+IMAGE_SIZE=""
+QUALITY=""
 NUM_IMAGES=1
 OUTPUT_FORMAT="png"
 OUTPUT_DIR=""
 FILENAME="edited"
 
-# Parse args
 while [ $# -gt 0 ]; do
     case $1 in
         --prompt|-p) PROMPT="$2"; shift 2 ;;
         --image-urls|-i) IMAGE_URLS="$2"; shift 2 ;;
+        --model|-m) MODEL_OVERRIDE="$2"; shift 2 ;;
+        --mask-url) MASK_URL="$2"; shift 2 ;;
         --aspect-ratio|-a) ASPECT_RATIO="$2"; shift 2 ;;
         --resolution|-r) RESOLUTION="$2"; shift 2 ;;
+        --image-size) IMAGE_SIZE="$2"; shift 2 ;;
+        --quality) QUALITY="$2"; shift 2 ;;
         --num-images|-n) NUM_IMAGES="$2"; shift 2 ;;
         --output-format|-f) OUTPUT_FORMAT="$2"; shift 2 ;;
         --output-dir|-o) OUTPUT_DIR="$2"; shift 2 ;;
         --filename) FILENAME="$2"; shift 2 ;;
-        *) echo "Unknown option: $1"; exit 1 ;;
+        *) die "Unknown option: $1" ;;
     esac
 done
 
-if [ -z "$PROMPT" ]; then
-    echo "Error: --prompt is required"
-    exit 1
-fi
+load_config "$MODEL_OVERRIDE"
 
-if [ -z "$IMAGE_URLS" ]; then
-    echo "Error: --image-urls is required (comma-separated URLs, max 14)"
-    exit 1
-fi
+[ -n "$PROMPT" ] || die "--prompt is required"
+[ -n "$IMAGE_URLS" ] || die "--image-urls is required (comma-separated URLs, max 14)"
 
-# Escape prompt for JSON
-PROMPT_ESCAPED=$(printf '%s' "$PROMPT" | sed 's/\\/\\\\/g; s/"/\\"/g')
+IMAGE_URLS_JSON=$(json_array_from_csv "$IMAGE_URLS") || \
+    die "Failed to parse --image-urls. Pass a comma-separated list of URLs."
+SUBMIT_API_BASE=$(queue_api_base edit)
+REQUEST_API_BASE=$(request_api_base)
+REFERENCE_IMAGE_COUNT=$(count_csv_items "$IMAGE_URLS")
+PROMPT_JSON=$(json_quote "$PROMPT")
 
-# Convert comma-separated URLs to JSON array
-# Input: "url1,url2,url3"
-# Output: ["url1","url2","url3"]
-IMAGE_URLS_JSON=$(echo "$IMAGE_URLS" | sed 's/,/","/g' | sed 's/^/["/' | sed 's/$/"]/')
+case "$FAL_IMAGE_PROVIDER_RESOLVED" in
+    google)
+        [ -z "$IMAGE_SIZE" ] || die "--image-size is only supported with OpenAI GPT Image 2. Use --aspect-ratio/--resolution for Nano Banana."
+        [ -z "$MASK_URL" ] || die "--mask-url is only supported with OpenAI GPT Image 2 edit."
+        if [ -n "$QUALITY" ]; then
+            echo "Warning: --quality is ignored for Nano Banana." >&2
+        fi
 
-# Build JSON
-JSON_PAYLOAD="{\"prompt\":\"$PROMPT_ESCAPED\",\"image_urls\":$IMAGE_URLS_JSON,\"num_images\":$NUM_IMAGES,\"aspect_ratio\":\"$ASPECT_RATIO\",\"resolution\":\"$RESOLUTION\",\"output_format\":\"$OUTPUT_FORMAT\"}"
+        JSON_PAYLOAD="{\"prompt\":$PROMPT_JSON,\"image_urls\":$IMAGE_URLS_JSON,\"num_images\":$NUM_IMAGES,\"aspect_ratio\":\"$ASPECT_RATIO\",\"resolution\":\"$RESOLUTION\",\"output_format\":\"$OUTPUT_FORMAT\"}"
+        SETTINGS_LABEL="$ASPECT_RATIO, $RESOLUTION, $OUTPUT_FORMAT"
+        ;;
+    openai)
+        if [ -n "$QUALITY" ]; then
+            validate_openai_quality "$QUALITY" || die "Unsupported --quality '$QUALITY'. Use low, medium, or high."
+            EFFECTIVE_QUALITY="$QUALITY"
+        else
+            EFFECTIVE_QUALITY="$FAL_IMAGE_OPENAI_QUALITY_RESOLVED"
+        fi
+
+        IMAGE_SIZE_JSON=$(openai_image_size_json "$IMAGE_SIZE" "$ASPECT_RATIO" "$RESOLUTION" "true")
+        JSON_PAYLOAD="{\"prompt\":$PROMPT_JSON,\"image_urls\":$IMAGE_URLS_JSON,\"image_size\":$IMAGE_SIZE_JSON,\"quality\":\"$EFFECTIVE_QUALITY\",\"num_images\":$NUM_IMAGES,\"output_format\":\"$OUTPUT_FORMAT\""
+        if [ -n "$MASK_URL" ]; then
+            MASK_URL_JSON=$(json_quote "$MASK_URL")
+            JSON_PAYLOAD="$JSON_PAYLOAD,\"mask_url\":$MASK_URL_JSON"
+        fi
+        JSON_PAYLOAD="$JSON_PAYLOAD}"
+        SETTINGS_LABEL="$IMAGE_SIZE_JSON, $EFFECTIVE_QUALITY, $OUTPUT_FORMAT"
+        ;;
+    *)
+        die "Unsupported resolved provider '$FAL_IMAGE_PROVIDER_RESOLVED'"
+        ;;
+esac
 
 echo "Submitting edit request..."
+echo "Model: $(model_queue_name edit) ($FAL_IMAGE_SELECTION_SOURCE)"
 printf "Prompt: %.100s...\n" "$PROMPT"
-echo "Reference images: $(echo "$IMAGE_URLS" | tr ',' '\n' | wc -l | tr -d ' ')"
-echo "Settings: $ASPECT_RATIO, $RESOLUTION, $OUTPUT_FORMAT"
+echo "Reference images: $REFERENCE_IMAGE_COUNT"
+echo "Settings: $SETTINGS_LABEL"
 echo ""
 
-# Submit to queue (API_BASE includes /edit for submit)
-SUBMIT_RESPONSE=$(curl -s -X POST "$API_BASE" \
-    -H "Authorization: Key $FAL_KEY" \
-    -H "Content-Type: application/json" \
-    -d "$JSON_PAYLOAD")
+SUBMIT_RESPONSE=$(submit_queue_request "$SUBMIT_API_BASE" "$JSON_PAYLOAD")
+REQUEST_ID=$(extract_request_id "$SUBMIT_RESPONSE")
 
-# Extract request_id via grep (handles optional space after colon)
-REQUEST_ID=$(echo "$SUBMIT_RESPONSE" | grep -oE '"request_id":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
-
-if [ -z "$REQUEST_ID" ]; then
-    echo "Error: Failed to submit request"
-    echo "$SUBMIT_RESPONSE"
+[ -n "$REQUEST_ID" ] || {
+    echo "Error: Failed to submit request" >&2
+    echo "$SUBMIT_RESPONSE" >&2
     exit 1
-fi
+}
 
 echo "Request ID: $REQUEST_ID"
 echo "Waiting for generation..."
 
-# Poll for completion (STATUS_BASE without /edit for polling)
-MAX_ATTEMPTS=60
-ATTEMPT=0
+wait_for_request "$REQUEST_API_BASE" "$REQUEST_ID"
+RESULT=$(fetch_queue_result "$REQUEST_API_BASE" "$REQUEST_ID")
 
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-    STATUS_RESPONSE=$(curl -s "$STATUS_BASE/requests/$REQUEST_ID/status" \
-        -H "Authorization: Key $FAL_KEY")
+download_result_images "$RESULT" "$OUTPUT_DIR" "$FILENAME" "$OUTPUT_FORMAT" "$NUM_IMAGES"
 
-    STATUS=$(echo "$STATUS_RESPONSE" | grep -oE '"status":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
-
-    case "$STATUS" in
-        COMPLETED)
-            echo "Generation complete!"
-            echo ""
-            break
-            ;;
-        FAILED)
-            echo "Error: Generation failed"
-            echo "$STATUS_RESPONSE"
-            exit 1
-            ;;
-        IN_PROGRESS|IN_QUEUE|PENDING)
-            echo "Status: $STATUS..."
-            sleep 2
-            ATTEMPT=$((ATTEMPT + 1))
-            ;;
-        *)
-            echo "Status: $STATUS (unknown, retrying)..."
-            sleep 2
-            ATTEMPT=$((ATTEMPT + 1))
-            ;;
-    esac
-done
-
-if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
-    echo "Error: Timeout waiting for generation"
-    exit 1
-fi
-
-# Get result (STATUS_BASE without /edit)
-RESULT=$(curl -s "$STATUS_BASE/requests/$REQUEST_ID" \
-    -H "Authorization: Key $FAL_KEY")
-
-# Download images if output_dir specified
-if [ -n "$OUTPUT_DIR" ]; then
-    mkdir -p "$OUTPUT_DIR"
-    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-    # Extract URLs via grep and download (handles optional space after colon)
-    URLS=$(echo "$RESULT" | grep -oE '"url":[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
-    INDEX=0
-
-    echo "Downloading images..."
-    for URL in $URLS; do
-        SUFFIX=""
-        [ "$NUM_IMAGES" -gt 1 ] && SUFFIX="_$INDEX"
-        OUTPUT_PATH="$OUTPUT_DIR/${FILENAME}_${TIMESTAMP}${SUFFIX}.${OUTPUT_FORMAT}"
-
-        if curl -s -o "$OUTPUT_PATH" "$URL"; then
-            echo "Saved: $OUTPUT_PATH"
-        else
-            echo "Warning: Failed to download $URL"
-        fi
-        INDEX=$((INDEX + 1))
-    done
-    echo ""
-fi
-
-# Output raw JSON for Claude to parse
 echo "=== RESULT JSON ==="
-echo "$RESULT"
+printf '%s\n' "$RESULT"
 echo "=== END RESULT ==="
 echo ""
 echo "Note: URLs expire in ~1 hour"

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/generate.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/generate.sh
@@ -1,158 +1,110 @@
 #!/bin/sh
-# Generate images using fal.ai nano-banana-pro model
-# POSIX sh compatible — works in cloud sandboxes and locally
+# Generate images via fal.ai.
+# Supports Nano Banana Pro and OpenAI GPT Image 2 (selected via config/.env).
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-CONFIG_FILE="$SCRIPT_DIR/../config/.env"
-API_BASE="https://queue.fal.run/fal-ai/nano-banana-pro"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/common.sh"
 
-# Load config
-if [ -f "$CONFIG_FILE" ]; then
-    # shellcheck disable=SC1090
-    . "$CONFIG_FILE"
-fi
-
-if [ -z "$FAL_KEY" ]; then
-    echo "Error: FAL_KEY not found. Set in config/.env or environment."
-    exit 1
-fi
-
-# Defaults
 PROMPT=""
+MODEL_OVERRIDE=""
 ASPECT_RATIO="1:1"
 RESOLUTION="1K"
+IMAGE_SIZE=""
+QUALITY=""
 NUM_IMAGES=1
 OUTPUT_FORMAT="png"
 OUTPUT_DIR=""
 FILENAME="generated"
 WEB_SEARCH="false"
 
-# Parse args
 while [ $# -gt 0 ]; do
     case $1 in
         --prompt|-p) PROMPT="$2"; shift 2 ;;
+        --model|-m) MODEL_OVERRIDE="$2"; shift 2 ;;
         --aspect-ratio|-a) ASPECT_RATIO="$2"; shift 2 ;;
         --resolution|-r) RESOLUTION="$2"; shift 2 ;;
+        --image-size) IMAGE_SIZE="$2"; shift 2 ;;
+        --quality) QUALITY="$2"; shift 2 ;;
         --num-images|-n) NUM_IMAGES="$2"; shift 2 ;;
         --output-format|-f) OUTPUT_FORMAT="$2"; shift 2 ;;
         --output-dir|-o) OUTPUT_DIR="$2"; shift 2 ;;
         --filename) FILENAME="$2"; shift 2 ;;
         --web-search|-w) WEB_SEARCH="true"; shift ;;
-        *) echo "Unknown option: $1"; exit 1 ;;
+        *) die "Unknown option: $1" ;;
     esac
 done
 
-if [ -z "$PROMPT" ]; then
-    echo "Error: --prompt is required"
-    exit 1
-fi
+load_config "$MODEL_OVERRIDE"
 
-# Escape prompt for JSON
-PROMPT_ESCAPED=$(printf '%s' "$PROMPT" | sed 's/\\/\\\\/g; s/"/\\"/g')
+[ -n "$PROMPT" ] || die "--prompt is required"
 
-# Build JSON
-JSON_PAYLOAD="{\"prompt\":\"$PROMPT_ESCAPED\",\"num_images\":$NUM_IMAGES,\"aspect_ratio\":\"$ASPECT_RATIO\",\"resolution\":\"$RESOLUTION\",\"output_format\":\"$OUTPUT_FORMAT\""
-if [ "$WEB_SEARCH" = "true" ]; then
-    JSON_PAYLOAD="$JSON_PAYLOAD,\"enable_web_search\":true"
-fi
-JSON_PAYLOAD="$JSON_PAYLOAD}"
+SUBMIT_API_BASE=$(queue_api_base generate)
+REQUEST_API_BASE=$(request_api_base)
+PROMPT_JSON=$(json_quote "$PROMPT")
+
+case "$FAL_IMAGE_PROVIDER_RESOLVED" in
+    google)
+        [ -z "$IMAGE_SIZE" ] || die "--image-size is only supported with OpenAI GPT Image 2. Use --aspect-ratio/--resolution for Nano Banana."
+        if [ -n "$QUALITY" ]; then
+            echo "Warning: --quality is ignored for Nano Banana." >&2
+        fi
+
+        JSON_PAYLOAD="{\"prompt\":$PROMPT_JSON,\"num_images\":$NUM_IMAGES,\"aspect_ratio\":\"$ASPECT_RATIO\",\"resolution\":\"$RESOLUTION\",\"output_format\":\"$OUTPUT_FORMAT\""
+        if [ "$WEB_SEARCH" = "true" ]; then
+            JSON_PAYLOAD="$JSON_PAYLOAD,\"enable_web_search\":true"
+        fi
+        JSON_PAYLOAD="$JSON_PAYLOAD}"
+        SETTINGS_LABEL="$ASPECT_RATIO, $RESOLUTION, $OUTPUT_FORMAT"
+        ;;
+    openai)
+        if [ "$WEB_SEARCH" = "true" ]; then
+            echo "Warning: --web-search is not supported by openai/gpt-image-2 and will be ignored." >&2
+        fi
+
+        if [ -n "$QUALITY" ]; then
+            validate_openai_quality "$QUALITY" || die "Unsupported --quality '$QUALITY'. Use low, medium, or high."
+            EFFECTIVE_QUALITY="$QUALITY"
+        else
+            EFFECTIVE_QUALITY="$FAL_IMAGE_OPENAI_QUALITY_RESOLVED"
+        fi
+
+        IMAGE_SIZE_JSON=$(openai_image_size_json "$IMAGE_SIZE" "$ASPECT_RATIO" "$RESOLUTION" "false")
+        JSON_PAYLOAD="{\"prompt\":$PROMPT_JSON,\"image_size\":$IMAGE_SIZE_JSON,\"quality\":\"$EFFECTIVE_QUALITY\",\"num_images\":$NUM_IMAGES,\"output_format\":\"$OUTPUT_FORMAT\"}"
+        SETTINGS_LABEL="$IMAGE_SIZE_JSON, $EFFECTIVE_QUALITY, $OUTPUT_FORMAT"
+        ;;
+    *)
+        die "Unsupported resolved provider '$FAL_IMAGE_PROVIDER_RESOLVED'"
+        ;;
+esac
 
 echo "Submitting request..."
+echo "Model: $FAL_IMAGE_MODEL_RESOLVED ($FAL_IMAGE_SELECTION_SOURCE)"
 printf "Prompt: %.100s...\n" "$PROMPT"
-echo "Settings: $ASPECT_RATIO, $RESOLUTION, $OUTPUT_FORMAT"
+echo "Settings: $SETTINGS_LABEL"
 echo ""
 
-# Submit to queue
-SUBMIT_RESPONSE=$(curl -s -X POST "$API_BASE" \
-    -H "Authorization: Key $FAL_KEY" \
-    -H "Content-Type: application/json" \
-    -d "$JSON_PAYLOAD")
+SUBMIT_RESPONSE=$(submit_queue_request "$SUBMIT_API_BASE" "$JSON_PAYLOAD")
+REQUEST_ID=$(extract_request_id "$SUBMIT_RESPONSE")
 
-# Extract request_id via grep (handles optional space after colon)
-REQUEST_ID=$(echo "$SUBMIT_RESPONSE" | grep -oE '"request_id":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
-
-if [ -z "$REQUEST_ID" ]; then
-    echo "Error: Failed to submit request"
-    echo "$SUBMIT_RESPONSE"
+[ -n "$REQUEST_ID" ] || {
+    echo "Error: Failed to submit request" >&2
+    echo "$SUBMIT_RESPONSE" >&2
     exit 1
-fi
+}
 
 echo "Request ID: $REQUEST_ID"
 echo "Waiting for generation..."
 
-# Poll for completion
-MAX_ATTEMPTS=60
-ATTEMPT=0
+wait_for_request "$REQUEST_API_BASE" "$REQUEST_ID"
+RESULT=$(fetch_queue_result "$REQUEST_API_BASE" "$REQUEST_ID")
 
-while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-    STATUS_RESPONSE=$(curl -s "$API_BASE/requests/$REQUEST_ID/status" \
-        -H "Authorization: Key $FAL_KEY")
+download_result_images "$RESULT" "$OUTPUT_DIR" "$FILENAME" "$OUTPUT_FORMAT" "$NUM_IMAGES"
 
-    STATUS=$(echo "$STATUS_RESPONSE" | grep -oE '"status":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
-
-    case "$STATUS" in
-        COMPLETED)
-            echo "Generation complete!"
-            echo ""
-            break
-            ;;
-        FAILED)
-            echo "Error: Generation failed"
-            echo "$STATUS_RESPONSE"
-            exit 1
-            ;;
-        IN_PROGRESS|IN_QUEUE|PENDING)
-            echo "Status: $STATUS..."
-            sleep 2
-            ATTEMPT=$((ATTEMPT + 1))
-            ;;
-        *)
-            echo "Status: $STATUS (unknown, retrying)..."
-            sleep 2
-            ATTEMPT=$((ATTEMPT + 1))
-            ;;
-    esac
-done
-
-if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
-    echo "Error: Timeout waiting for generation"
-    exit 1
-fi
-
-# Get result
-RESULT=$(curl -s "$API_BASE/requests/$REQUEST_ID" \
-    -H "Authorization: Key $FAL_KEY")
-
-# Download images if output_dir specified
-if [ -n "$OUTPUT_DIR" ]; then
-    mkdir -p "$OUTPUT_DIR"
-    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-    # Extract URLs via grep and download (handles optional space after colon)
-    URLS=$(echo "$RESULT" | grep -oE '"url":[[:space:]]*"[^"]*"' | sed 's/.*"\([^"]*\)"$/\1/')
-    INDEX=0
-
-    echo "Downloading images..."
-    for URL in $URLS; do
-        SUFFIX=""
-        [ "$NUM_IMAGES" -gt 1 ] && SUFFIX="_$INDEX"
-        OUTPUT_PATH="$OUTPUT_DIR/${FILENAME}_${TIMESTAMP}${SUFFIX}.${OUTPUT_FORMAT}"
-
-        if curl -s -o "$OUTPUT_PATH" "$URL"; then
-            echo "Saved: $OUTPUT_PATH"
-        else
-            echo "Warning: Failed to download $URL"
-        fi
-        INDEX=$((INDEX + 1))
-    done
-    echo ""
-fi
-
-# Output raw JSON for Claude to parse
 echo "=== RESULT JSON ==="
-echo "$RESULT"
+printf '%s\n' "$RESULT"
 echo "=== END RESULT ==="
 echo ""
 echo "Note: URLs expire in ~1 hour"

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/run.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/run.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Test runner for fal-ai-image skill — no network.
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=""
+
+for t in "$TESTS_DIR"/test_*.sh; do
+    [ -f "$t" ] || continue
+    name=$(basename "$t" .sh)
+    printf '%s ... ' "$name"
+    if sh "$t" >/dev/null 2>&1; then
+        printf 'PASS\n'
+        PASS=$((PASS + 1))
+    else
+        printf 'FAIL\n'
+        FAIL=$((FAIL + 1))
+        FAILED_TESTS="$FAILED_TESTS $name"
+        echo "--- output of $name ---"
+        sh "$t" 2>&1 || true
+        echo "--- end ---"
+    fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    echo "Failed:$FAILED_TESTS"
+    exit 1
+fi

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/test_config_selector.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/test_config_selector.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# Test config selector logic for fal-ai-image.
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+run_selector() {
+    _label="$1"
+    _provider="$2"
+    _model="$3"
+    _quality="$4"
+    _cli_model="$5"
+
+    _td="${TMPDIR:-/tmp}/fal_image_test_$$_$(printf '%s' "$_label" | tr ' /+' '___')"
+    rm -rf "$_td"
+    mkdir -p "$_td"
+
+    {
+        echo "FAL_KEY=test-key"
+        [ -n "$_provider" ] && echo "FAL_IMAGE_PROVIDER=$_provider"
+        [ -n "$_model" ] && echo "FAL_IMAGE_MODEL=$_model"
+        [ -n "$_quality" ] && echo "FAL_IMAGE_OPENAI_QUALITY=$_quality"
+    } > "$_td/.env"
+
+    _result=$(
+        FAL_AI_IMAGE_CONFIG_FILE="$_td/.env"
+        export FAL_AI_IMAGE_CONFIG_FILE
+
+        # shellcheck disable=SC1091
+        . "$SCRIPTS_DIR/common.sh"
+
+        if ( load_config "$_cli_model" ) >/dev/null 2>&1; then
+            load_config "$_cli_model" >/dev/null
+            printf 'PROVIDER=%s\nMODEL=%s\nQUALITY=%s\n' \
+                "$FAL_IMAGE_PROVIDER_RESOLVED" \
+                "$FAL_IMAGE_MODEL_RESOLVED" \
+                "$FAL_IMAGE_OPENAI_QUALITY_RESOLVED"
+        else
+            printf 'DIE\n'
+        fi
+    )
+
+    rm -rf "$_td"
+    printf '%s' "$_result"
+}
+
+assert_contains() {
+    _label="$1"
+    _haystack="$2"
+    _needle="$3"
+
+    case "$_haystack" in
+        *"$_needle"*)
+            echo "  ok: $_label contains $_needle"
+            ;;
+        *)
+            echo "  FAIL: $_label missing $_needle"
+            echo "    full output: $_haystack"
+            exit 1
+            ;;
+    esac
+}
+
+assert_die() {
+    _label="$1"
+    _result="$2"
+
+    case "$_result" in
+        *DIE*)
+            echo "  ok: $_label died as expected"
+            ;;
+        *)
+            echo "  FAIL: $_label expected DIE, got: $_result"
+            exit 1
+            ;;
+    esac
+}
+
+out=$(run_selector "default" "" "" "" "")
+assert_contains "default selector" "$out" "PROVIDER=google"
+assert_contains "default selector" "$out" "MODEL=fal-ai/nano-banana-pro"
+assert_contains "default selector" "$out" "QUALITY=medium"
+
+out=$(run_selector "provider_openai" "openai" "" "" "")
+assert_contains "provider=openai" "$out" "PROVIDER=openai"
+assert_contains "provider=openai" "$out" "MODEL=openai/gpt-image-2"
+
+out=$(run_selector "provider_alias" "gpt" "" "high" "")
+assert_contains "provider alias" "$out" "PROVIDER=openai"
+assert_contains "provider alias" "$out" "QUALITY=high"
+
+out=$(run_selector "model_wins" "google" "openai/gpt-image-2" "" "")
+assert_contains "explicit model wins" "$out" "PROVIDER=openai"
+assert_contains "explicit model wins" "$out" "MODEL=openai/gpt-image-2"
+
+out=$(run_selector "cli_override_wins" "google" "" "" "gpt")
+assert_contains "cli override wins" "$out" "PROVIDER=openai"
+assert_contains "cli override wins" "$out" "MODEL=openai/gpt-image-2"
+
+out=$(run_selector "cli_alias_gemini" "openai" "" "" "gemini")
+assert_contains "cli alias gemini" "$out" "PROVIDER=google"
+assert_contains "cli alias gemini" "$out" "MODEL=fal-ai/nano-banana-pro"
+
+out=$(run_selector "invalid_provider" "banana-party" "" "" "")
+assert_die "invalid provider" "$out"
+
+out=$(run_selector "invalid_quality" "openai" "" "ultra" "")
+assert_die "invalid quality" "$out"
+
+out=$(run_selector "invalid_cli_model" "" "" "" "banana-party")
+assert_die "invalid cli model" "$out"
+
+echo "test_config_selector: all passed"

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/test_edit_openai_mask.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/test_edit_openai_mask.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Test that edit.sh forwards mask_url to openai/gpt-image-2/edit.
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fal_image_edit_mask.XXXXXX")
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT TERM
+
+cat > "$TMP_DIR/.env" <<'EOF'
+FAL_KEY=test-key
+FAL_IMAGE_PROVIDER=openai
+EOF
+
+mkdir -p "$TMP_DIR/bin"
+
+cat > "$TMP_DIR/bin/curl" <<'EOF'
+#!/bin/sh
+set -e
+
+LOG_DIR="${FAL_TEST_LOG_DIR:?}"
+URL=""
+DATA=""
+NEXT_IS_DATA="false"
+
+for arg in "$@"; do
+    if [ "$NEXT_IS_DATA" = "true" ]; then
+        DATA="$arg"
+        NEXT_IS_DATA="false"
+        continue
+    fi
+
+    case "$arg" in
+        -d)
+            NEXT_IS_DATA="true"
+            ;;
+        http://*|https://*)
+            URL="$arg"
+            ;;
+    esac
+done
+
+printf '%s\n' "$URL" >> "$LOG_DIR/url.txt"
+[ -n "$DATA" ] && printf '%s\n' "$DATA" > "$LOG_DIR/payload.json"
+
+case "$URL" in
+    */status)
+        printf '{"status":"COMPLETED"}'
+        ;;
+    */requests/req-test)
+        printf '{"images":[{"url":"https://example.com/result.png","content_type":"image/png","file_name":"result.png"}]}'
+        ;;
+    *)
+        printf '{"request_id":"req-test"}'
+        ;;
+esac
+EOF
+
+chmod +x "$TMP_DIR/bin/curl"
+
+FAL_AI_IMAGE_CONFIG_FILE="$TMP_DIR/.env"
+FAL_TEST_LOG_DIR="$TMP_DIR/logs"
+PATH="$TMP_DIR/bin:$PATH"
+export FAL_AI_IMAGE_CONFIG_FILE FAL_TEST_LOG_DIR PATH
+
+mkdir -p "$FAL_TEST_LOG_DIR"
+
+sh "$SCRIPTS_DIR/edit.sh" \
+  --model gpt \
+  --prompt "targeted edit" \
+  --image-urls "https://example.com/source.png" \
+  --mask-url "https://example.com/mask.png" \
+  --image-size auto \
+  >/dev/null
+
+grep '"mask_url":"https://example.com/mask.png"' "$FAL_TEST_LOG_DIR/payload.json" >/dev/null
+grep 'https://queue.fal.run/openai/gpt-image-2/edit' "$FAL_TEST_LOG_DIR/url.txt" >/dev/null
+grep 'https://queue.fal.run/openai/gpt-image-2/requests/req-test/status' "$FAL_TEST_LOG_DIR/url.txt" >/dev/null
+
+echo "test_edit_openai_mask: all passed"

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/test_openai_image_size.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/test_openai_image_size.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Test OpenAI image_size helper.
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fal_image_size_test.XXXXXX")
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT TERM
+
+cat > "$TMP_DIR/.env" <<'EOF'
+FAL_KEY=test-key
+FAL_IMAGE_PROVIDER=openai
+EOF
+
+FAL_AI_IMAGE_CONFIG_FILE="$TMP_DIR/.env"
+export FAL_AI_IMAGE_CONFIG_FILE
+
+# shellcheck disable=SC1091
+. "$SCRIPTS_DIR/common.sh"
+
+load_config >/dev/null
+
+square=$(openai_image_size_json "" "1:1" "1K" "false")
+[ "$square" = '{"width":1024,"height":1024}' ]
+
+landscape=$(openai_image_size_json "" "4:3" "2K" "false")
+[ "$landscape" = '{"width":2048,"height":1536}' ]
+
+preset=$(openai_image_size_json "portrait_16_9" "1:1" "1K" "false")
+[ "$preset" = '"portrait_16_9"' ]
+
+auto_size=$(openai_image_size_json "" "auto" "1K" "true")
+[ "$auto_size" = '"auto"' ]
+
+custom=$(openai_image_size_json "1280x720" "1:1" "1K" "false")
+[ "$custom" = '{"width":1280,"height":720}' ]
+
+if openai_image_size_json "1000x700" "1:1" "1K" "false" >/dev/null 2>&1; then
+    echo "Expected invalid custom size to fail"
+    exit 1
+fi
+
+echo "test_openai_image_size: all passed"

--- a/plugins/fal-ai-image/skills/fal-ai-image/scripts/upload.sh
+++ b/plugins/fal-ai-image/skills/fal-ai-image/scripts/upload.sh
@@ -7,18 +7,10 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-CONFIG_FILE="$SCRIPT_DIR/../config/.env"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/common.sh"
 
-# Load config
-if [ -f "$CONFIG_FILE" ]; then
-    # shellcheck disable=SC1090
-    . "$CONFIG_FILE"
-fi
-
-if [ -z "$FAL_KEY" ]; then
-    echo "Error: FAL_KEY not found. Set in config/.env or environment."
-    exit 1
-fi
+load_config
 
 # Defaults
 FILE_PATH=""


### PR DESCRIPTION
## What changed

This PR expands `fal-ai-image` from a Nano Banana-only skill into a dual-model image skill that supports both:

- `fal-ai/nano-banana-pro`
- `openai/gpt-image-2`

Key changes:

- added shared config/queue helpers in `scripts/common.sh`
- added config-driven model selection with backward-compatible fallback to Nano Banana
- added one-off CLI override via `--model`
- mapped user-friendly aliases:
  - `gpt` / `openai` -> GPT Image 2
  - `nano-banana` / `google` / `gemini` -> Nano Banana
- added OpenAI-specific params support:
  - `--image-size`
  - `--quality`
  - `--mask-url` for `openai/gpt-image-2/edit`
- kept old `--aspect-ratio` / `--resolution` flows usable by deriving valid OpenAI image sizes when needed
- fixed edit queue polling/result fetching to use the correct base request endpoint after `/edit` submission
- added references docs for model selection and editing/mask behavior
- added shell tests for selector logic, OpenAI image size conversion, and masked edit payloads
- updated plugin metadata and top-level README descriptions

## Why this changed

The existing skill only supported Nano Banana and had no clean way to switch models per request. The goal was to let users opt into GPT Image 2 while preserving backward compatibility for existing installs and prompts.

During live validation, the edit flow also exposed a bug in polling/result retrieval for `/edit` jobs, which is fixed here.

## User impact

Users can now:

- keep old behavior with only `FAL_KEY` configured
- switch the default backend in config
- force a specific model on one request with `--model`
- use GPT edit with `mask_url` for localized edits

The skill docs now also explain when to use masks, how model selection is resolved, and the limits of masked editing for GPT.

## Validation

Automated:

- `sh plugins/fal-ai-image/skills/fal-ai-image/scripts/tests/run.sh`

Live API checks against fal:

- Nano Banana generate
- GPT Image 2 generate
- Nano Banana edit
- GPT Image 2 edit without mask
- GPT Image 2 edit with mask
- GPT Image 2 masked stress test to confirm mask guidance behavior

These runs were kept within a small spend envelope and confirmed the new flow end-to-end.
