### PR TITLE
[codex] Add SSH password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ claude --plugin-dir ./plugins/agent-deck
 
 ### [ssh-remote-connection](plugins/ssh-remote-connection/skills/ssh-remote-connection)
 
-SSH подключение к удалённым серверам с agent forwarding.
+SSH подключение к удалённым серверам по ключу или паролю.
 
 - Выполнение команд на удалённом сервере
 - Agent forwarding (`-A`) для использования локальных SSH ключей
+- Подключение по логину/паролю через `SSH_PASSWORD` при наличии `sshpass` или `expect`
 - Управление Docker контейнерами, просмотр логов
 
 **Триггеры (RU):**

--- a/plugins/ssh-remote-connection/.claude-plugin/plugin.json
+++ b/plugins/ssh-remote-connection/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ssh-remote-connection",
-  "description": "SSH подключение к удалённым серверам с agent forwarding",
+  "description": "SSH подключение к удалённым серверам по ключу или паролю",
   "version": "1.0.0",
   "author": {
     "name": "Polyakov"

--- a/plugins/ssh-remote-connection/skills/ssh-remote-connection/SKILL.md
+++ b/plugins/ssh-remote-connection/skills/ssh-remote-connection/SKILL.md
@@ -28,6 +28,25 @@ scripts/connect.sh "docker compose logs backend --tail 50"
 
 2. Fill in `config/.env` with actual values
 
+   Key-based authentication:
+   ```bash
+   SSH_HOST=your-server.example.com
+   SSH_USER=ubuntu
+   SSH_AUTH_METHOD=key
+   SSH_KEY_PATH=/absolute/path/to/private/key
+   SSH_KEY_PASSWORD=
+   SERVER_PROJECT_PATH=/path/to/project
+   ```
+
+   Password-based authentication:
+   ```bash
+   SSH_HOST=your-server.example.com
+   SSH_USER=ubuntu
+   SSH_AUTH_METHOD=password
+   SSH_PASSWORD='your account password'
+   SERVER_PROJECT_PATH=/path/to/project
+   ```
+
 3. Make script executable:
    ```bash
    chmod +x scripts/connect.sh
@@ -38,9 +57,16 @@ scripts/connect.sh "docker compose logs backend --tail 50"
 Set environment variables in your cloud configuration:
 - `SSH_HOST` — server hostname or IP
 - `SSH_USER` — SSH username
-- `SSH_KEY_PATH` — path to private key
+- `SSH_PORT` — SSH port (optional)
+- `SSH_AUTH_METHOD` — `auto`, `key`, or `password` (optional, defaults to `auto`)
+- `SSH_KEY_PATH` — path to private key for key authentication
 - `SSH_KEY_PASSWORD` — key passphrase (optional)
+- `SSH_PASSWORD` — SSH account password for password authentication
 - `SERVER_PROJECT_PATH` — project directory on server
+
+For password authentication, the local runtime must have either `sshpass` or `expect`.
+If the host key is not trusted yet, connect once manually or add the host to `known_hosts`
+before running non-interactive commands.
 
 ## Important Notes
 

--- a/plugins/ssh-remote-connection/skills/ssh-remote-connection/config/.env.example
+++ b/plugins/ssh-remote-connection/skills/ssh-remote-connection/config/.env.example
@@ -7,11 +7,22 @@ SSH_HOST=your-server.example.com
 # SSH username
 SSH_USER=ubuntu
 
-# Path to SSH private key (absolute path)
-SSH_KEY_PATH=/path/to/your/private/key
+# Optional SSH port. Leave empty to use OpenSSH default port 22.
+SSH_PORT=
 
-# SSH key password (optional, leave empty if key has no passphrase)
+# Authentication method: auto, key, or password.
+# auto uses SSH_KEY_PATH when it points to a readable file, otherwise SSH_PASSWORD.
+SSH_AUTH_METHOD=auto
+
+# Key authentication: path to SSH private key (absolute path).
+SSH_KEY_PATH=
+
+# Key passphrase (optional, leave empty if key has no passphrase).
 SSH_KEY_PASSWORD=
+
+# Password authentication: SSH account password.
+# If the password contains shell-special characters, wrap it in single quotes.
+SSH_PASSWORD=
 
 # Project directory on the server (optional, leave empty for home dir)
 SERVER_PROJECT_PATH=/path/to/project

--- a/plugins/ssh-remote-connection/skills/ssh-remote-connection/scripts/connect.sh
+++ b/plugins/ssh-remote-connection/skills/ssh-remote-connection/scripts/connect.sh
@@ -18,61 +18,175 @@ if [ -f "$ENV_FILE" ] && [ -z "$SSH_HOST" ]; then
     source "$ENV_FILE"
 fi
 
+SSH_AUTH_METHOD="${SSH_AUTH_METHOD:-auto}"
+
 # Validate required variables
-if [ -z "$SSH_HOST" ] || [ -z "$SSH_USER" ] || [ -z "$SSH_KEY_PATH" ]; then
+if [ -z "$SSH_HOST" ] || [ -z "$SSH_USER" ]; then
     echo "Error: Missing required variables"
-    echo "Required: SSH_HOST, SSH_USER, SSH_KEY_PATH"
+    echo "Required: SSH_HOST, SSH_USER"
     echo ""
     echo "For Claude Code: copy config/.env.example to config/.env"
     echo "For Cloud Runtime: set environment variables"
     exit 1
 fi
 
+case "$SSH_AUTH_METHOD" in
+    auto|"")
+        if [ -n "$SSH_KEY_PATH" ] && [ -r "$SSH_KEY_PATH" ]; then
+            AUTH_METHOD="key"
+        elif [ -n "$SSH_PASSWORD" ]; then
+            AUTH_METHOD="password"
+        elif [ -n "$SSH_KEY_PATH" ]; then
+            AUTH_METHOD="key"
+        else
+            AUTH_METHOD=""
+        fi
+        ;;
+    key|password)
+        AUTH_METHOD="$SSH_AUTH_METHOD"
+        ;;
+    *)
+        echo "Error: Invalid SSH_AUTH_METHOD: $SSH_AUTH_METHOD"
+        echo "Allowed values: auto, key, password"
+        exit 1
+        ;;
+esac
+
+if [ "$AUTH_METHOD" = "key" ]; then
+    if [ -z "$SSH_KEY_PATH" ]; then
+        echo "Error: SSH_KEY_PATH is required for key authentication"
+        exit 1
+    fi
+    if [ ! -r "$SSH_KEY_PATH" ]; then
+        echo "Error: SSH key is not readable: $SSH_KEY_PATH"
+        exit 1
+    fi
+elif [ "$AUTH_METHOD" = "password" ]; then
+    if [ -z "$SSH_PASSWORD" ]; then
+        echo "Error: SSH_PASSWORD is required for password authentication"
+        exit 1
+    fi
+else
+    echo "Error: Missing SSH authentication configuration"
+    echo "Set SSH_KEY_PATH for key authentication or SSH_PASSWORD for password authentication."
+    exit 1
+fi
+
 # Function to add key to ssh-agent if not already added
 add_key_to_agent() {
     # Check if key is already in agent
-    if ssh-add -l 2>/dev/null | grep -q "$SSH_KEY_PATH"; then
+    if ssh-add -l 2>/dev/null | grep -Fq "$SSH_KEY_PATH"; then
         return 0
     fi
 
     # Try to add key
     if [ -n "$SSH_KEY_PASSWORD" ]; then
         # Use expect to add key with password
-        expect -c "
-            spawn ssh-add $SSH_KEY_PATH
-            expect \"Enter passphrase\"
-            send \"$SSH_KEY_PASSWORD\r\"
+        if ! command -v expect >/dev/null 2>&1; then
+            echo "Error: SSH_KEY_PASSWORD requires expect to add the key non-interactively"
+            exit 1
+        fi
+        EXPECT_SSH_KEY_PATH="$SSH_KEY_PATH" EXPECT_SSH_KEY_PASSWORD="$SSH_KEY_PASSWORD" expect -c '
+            spawn ssh-add $env(EXPECT_SSH_KEY_PATH)
+            expect "Enter passphrase"
+            send -- "$env(EXPECT_SSH_KEY_PASSWORD)\r"
             expect eof
-        " > /dev/null 2>&1
+            catch wait result
+            exit [lindex $result 3]
+        ' > /dev/null 2>&1
     else
         # Try without password (will prompt if needed)
         ssh-add "$SSH_KEY_PATH" 2>/dev/null
     fi
 }
 
-# Start ssh-agent if not running
-if [ -z "$SSH_AUTH_SOCK" ]; then
-    eval "$(ssh-agent -s)" > /dev/null 2>&1
+run_ssh_with_password() {
+    if command -v sshpass >/dev/null 2>&1; then
+        SSHPASS="$SSH_PASSWORD" sshpass -e ssh "$@"
+        return $?
+    fi
+
+    if command -v expect >/dev/null 2>&1; then
+        EXPECT_SSH_PASSWORD="$SSH_PASSWORD" EXPECT_INTERACTIVE="${EXPECT_INTERACTIVE:-0}" expect -f - -- "$@" <<'EXPECT'
+            set timeout -1
+            set password $env(EXPECT_SSH_PASSWORD)
+            set interactive $env(EXPECT_INTERACTIVE)
+            log_user 0
+            spawn ssh {*}$argv
+            log_user 1
+            expect {
+                -nocase -re "are you sure you want to continue connecting.*" {
+                    puts stderr "Error: SSH host key is not trusted yet. Connect once manually or add the host to known_hosts."
+                    exit 6
+                }
+                -nocase -re "(password|passcode).*: *$" {
+                    send -- "$password\r"
+                    if {$interactive == "1"} {
+                        interact
+                        catch wait result
+                        exit [lindex $result 3]
+                    }
+                    exp_continue
+                }
+                eof {
+                    catch wait result
+                    exit [lindex $result 3]
+                }
+            }
+EXPECT
+        return $?
+    fi
+
+    echo "Error: Password authentication requires sshpass or expect."
+    echo "Install sshpass, install expect, or use SSH key authentication."
+    return 1
+}
+
+run_ssh() {
+    if [ "$AUTH_METHOD" = "password" ]; then
+        run_ssh_with_password "$@"
+    else
+        ssh "$@"
+    fi
+}
+
+SSH_ARGS=()
+if [ -n "$SSH_PORT" ]; then
+    SSH_ARGS+=("-p" "$SSH_PORT")
 fi
 
-# Add key to agent
-add_key_to_agent
+if [ "$AUTH_METHOD" = "key" ]; then
+    # Start ssh-agent if not running
+    if [ -z "$SSH_AUTH_SOCK" ]; then
+        eval "$(ssh-agent -s)" > /dev/null 2>&1
+    fi
+
+    # Add key to agent for the initial connection and forwarded auth on the server.
+    if ! add_key_to_agent; then
+        echo "Error: Failed to add SSH key to ssh-agent: $SSH_KEY_PATH"
+        exit 1
+    fi
+    SSH_ARGS+=("-A" "-i" "$SSH_KEY_PATH")
+else
+    SSH_ARGS+=("-o" "PreferredAuthentications=password,keyboard-interactive" "-o" "PubkeyAuthentication=no")
+fi
 
 # Build command prefix (cd to project dir if specified)
 if [ -n "$SERVER_PROJECT_PATH" ]; then
-    CD_CMD="cd $SERVER_PROJECT_PATH &&"
+    printf -v SERVER_PROJECT_PATH_QUOTED "%q" "$SERVER_PROJECT_PATH"
+    CD_CMD="cd $SERVER_PROJECT_PATH_QUOTED &&"
 else
     CD_CMD=""
 fi
 
 if [ -n "$1" ]; then
-    # Run provided command (-A enables agent forwarding)
-    ssh -A "$SSH_USER@$SSH_HOST" "$CD_CMD $*"
+    # Run provided command
+    run_ssh "${SSH_ARGS[@]}" "$SSH_USER@$SSH_HOST" "$CD_CMD $*"
 else
-    # Interactive shell (-A enables agent forwarding)
+    # Interactive shell
     if [ -n "$CD_CMD" ]; then
-        ssh -A -t "$SSH_USER@$SSH_HOST" "$CD_CMD exec \$SHELL -l"
+        EXPECT_INTERACTIVE=1 run_ssh "${SSH_ARGS[@]}" -t "$SSH_USER@$SSH_HOST" "$CD_CMD exec \$SHELL -l"
     else
-        ssh -A -t "$SSH_USER@$SSH_HOST"
+        EXPECT_INTERACTIVE=1 run_ssh "${SSH_ARGS[@]}" -t "$SSH_USER@$SSH_HOST"
     fi
 fi


### PR DESCRIPTION
## Summary

Adds password-based authentication support to the `ssh-remote-connection` skill while preserving the existing SSH key and agent forwarding flow.

## What changed

- Added `SSH_AUTH_METHOD=auto|key|password`, `SSH_PASSWORD`, and optional `SSH_PORT` configuration.
- Updated `connect.sh` to choose key auth when a readable key is configured, otherwise use password auth when `SSH_PASSWORD` is present.
- Added password auth execution through `sshpass`, with an `expect` fallback.
- Updated the skill docs, config example, plugin description, and repository README.

## Impact

Users can now configure the skill with only an SSH username and account password. Key-based auth still works and keeps agent forwarding enabled for server-side Git operations.

## Validation

- `bash -n plugins/ssh-remote-connection/skills/ssh-remote-connection/scripts/connect.sh`
- `git diff --cached --check`
- Password auth path smoke-checked locally through both `sshpass` and `expect` using invalid-port dry runs, without connecting to a real server.
- Key auth validation smoke-checked with an unreadable key path.