### PR TITLE
fix(codex-review): redirect codex exec stdin to /dev/null

### DIFF
--- a/plugins/codex-review/.claude-plugin/plugin.json
+++ b/plugins/codex-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review",
   "description": "Cross-agent review workflow: Claude implements, Codex reviews",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Polyakov"
   },

--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -371,7 +371,7 @@ cmd_init() {
         "${MODEL_FLAG[@]}" \
         "${YOLO_FLAG[@]}" \
         -o "$output_file" \
-        "$prompt" > "$log_file" 2>&1 || {
+        "$prompt" </dev/null > "$log_file" 2>&1 || {
         echo "ERROR: Failed to create Codex session." >&2
         cat "$log_file" >&2
         exit 1
@@ -486,7 +486,7 @@ cmd_review() {
         "${YOLO_FLAG[@]}" \
         -o "$output_file" \
         resume "$SESSION_ID" \
-        "$codex_prompt" > "$log_file" 2>&1 || {
+        "$codex_prompt" </dev/null > "$log_file" 2>&1 || {
         local exit_code=$?
         echo "ERROR: Codex exec failed (exit $exit_code)." >&2
         cat "$log_file" >&2


### PR DESCRIPTION
## Summary

Fixes #103 — `codex exec` hangs on `Reading additional input from stdin...` when invoked from a non-TTY parent (Claude Code Bash tool, CI runners, plain `subprocess.run` without `stdin=DEVNULL`).

`codex exec --help` documents this behaviour: when stdin is piped and a prompt is also provided, stdin is appended as a `<stdin>` block. Under a non-TTY parent the inherited fd never closes during the parent turn, so codex blocks indefinitely.

## Changes

Redirected `codex exec` stdin to `/dev/null` in both call sites of `scripts/codex-review.sh`:

- `cmd_init` (line 370) — initial Codex session
- `cmd_review` (line 483) — `resume` invocations for plan/code review cycles

TTY callers were already not piping stdin, so behaviour is unchanged for them.

Bumped plugin version `1.2.0` → `1.2.1`.

## Verification

- Verified these are the only `codex exec` invocations in the plugin (other `codex` mentions are `command -v codex` and `codex --version` checks — not blocking).
- Repro from the issue (`bash …/codex-review.sh init "test"` from a non-TTY parent) now completes instead of hanging.