### PR TITLE
[codex] add publisher image optimization

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,13 +99,13 @@
     },
     {
       "name": "github-pages-publisher",
-      "description": "Публикация статических артифактов на GitHub Pages с YYYY/YYYY-MM структурой и viewport-валидацией",
+      "description": "Публикация статических артифактов на GitHub Pages с YYYY/YYYY-MM структурой, viewport-валидацией и опциональной оптимизацией картинок",
       "source": "./plugins/github-pages-publisher",
       "category": "development"
     },
     {
       "name": "sourcecraft-publisher",
-      "description": "Публикация статических артифактов на SourceCraft Sites (Yandex, работает в России)",
+      "description": "Публикация статических артифактов на SourceCraft Sites (Yandex, работает в России) с опциональной оптимизацией картинок",
       "source": "./plugins/sourcecraft-publisher",
       "category": "development"
     },

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 token.txt
 .DS_Store
+.claude/
 .claude/settings*
 __pycache__/
 

--- a/plugins/github-pages-publisher/.claude-plugin/plugin.json
+++ b/plugins/github-pages-publisher/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-pages-publisher",
   "version": "1.0.0",
-  "description": "Publish static page artifacts to a GitHub Pages repository with year/month directory layout and viewport validation",
+  "description": "Publish static page artifacts to a GitHub Pages repository with year/month directory layout, viewport validation, and optional image optimization",
   "author": {
     "name": "Polyakov"
   }

--- a/plugins/github-pages-publisher/skills/github-pages-publisher/SKILL.md
+++ b/plugins/github-pages-publisher/skills/github-pages-publisher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-pages-publisher
-description: Publish static page artifacts from the publisher workspace to a GitHub Pages repository using a fine-grained token. Use when a React/static page artifact is already prepared and needs to be copied into the Pages repo under a strict year/year-month/page-slug directory layout, then committed and pushed, with a final public artifact URL returned.
+description: Publish static page artifacts from the publisher workspace to a GitHub Pages repository using a fine-grained token, with advisory image optimization and an original-image path. Use when a React/static page artifact is already prepared and needs to be copied into the Pages repo under a strict year/year-month/page-slug directory layout, then committed and pushed, with a final public artifact URL returned.
 ---
 
 # GitHub Pages Publisher
@@ -61,10 +61,34 @@ Prefer the clean directory URL when it resolves correctly.
 2. Create or update target directory:
    - `<year>/<year-month>/<page-slug>/`
 3. Copy artifact files into that directory
-4. Verify there is an entrypoint (`index.html` normally)
-5. Run pre-publish validation (see section above)
-6. Commit and push to the Pages repo using the configured fine-grained token workflow
-7. Return the final public URL
+4. Optimize oversized raster images when practical, unless original-size sharing is intentional
+5. Verify there is an entrypoint (`index.html` normally)
+6. Run pre-publish validation (see section above)
+7. Commit and push to the Pages repo using the configured fine-grained token workflow
+8. Return the final public URL
+
+## Publishing command
+
+```bash
+python3 scripts/publish_static.py --source <dir-or-html> --slug <name> [--date YYYY-MM-DD] [--image-max-kb 500]
+```
+
+The script copies the artifact into `YYYY/YYYY-MM/slug/`, optimizes oversized `.jpg`, `.jpeg`, `.png`, and `.webp` images, commits, pushes, and prints the final public URL.
+
+## Image optimization
+
+Image optimization is a recommendation, not a hard requirement. By default, the publishing script tries to keep each raster image under `500KB` by stripping metadata, recompressing, and resizing long edges when needed.
+
+Use `--image-max-kb <kb>` for a different target.
+Use `--keep-large-images` or `--image-max-kb 0` when the user explicitly needs original-size images (for example, a full-resolution infographic, map, or downloadable media asset).
+
+The original `--source` artifact is not changed. Optimization happens only after files are copied into the publish repo target directory. If Pillow/uv is unavailable or optimization fails, continue publishing originals and mention the warning.
+
+Manual console run for a prepared artifact:
+
+```bash
+uv run --with pillow python3 scripts/optimize_images.py <artifact-dir> --max-kb 500
+```
 
 ## Slug rules
 
@@ -77,6 +101,7 @@ Prefer the clean directory URL when it resolves correctly.
 
 Before pushing, the agent must verify:
 - artifact has `index.html` entrypoint
+- oversized raster images are optimized when practical, unless original-size sharing is intentional
 - no absolute local paths in HTML/CSS
 - no secrets in files
 - all local assets reachable from the target folder

--- a/plugins/github-pages-publisher/skills/github-pages-publisher/references/publish-checklist.md
+++ b/plugins/github-pages-publisher/skills/github-pages-publisher/references/publish-checklist.md
@@ -4,6 +4,7 @@ Before push:
 - target path follows `YYYY/YYYY-MM/page-slug/`
 - artifact has `index.html`
 - all local assets remain reachable from that folder
+- oversized raster images are optimized when practical or intentionally kept large
 - no accidental absolute local paths
 - no secrets in files
 - final URL is computed and returned

--- a/plugins/github-pages-publisher/skills/github-pages-publisher/scripts/optimize_images.py
+++ b/plugins/github-pages-publisher/skills/github-pages-publisher/scripts/optimize_images.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Optimize oversized raster images in-place before publishing."""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageOps, UnidentifiedImageError
+except ImportError as exc:
+    raise SystemExit(
+        'Pillow is required. Run with: '
+        'uv run --with pillow python3 scripts/optimize_images.py <path> --max-kb 500'
+    ) from exc
+
+
+IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp'}
+DEFAULT_MAX_KB = 500
+DEFAULT_MAX_DIMENSION = 1800
+MIN_DIMENSION = 640
+QUALITY_VALUES = range(85, 40, -5)
+RESAMPLE = getattr(getattr(Image, 'Resampling', Image), 'LANCZOS')
+
+
+@dataclass
+class OptimizeResult:
+    status: str
+    original_size: int
+    final_size: int
+    reason: str = ''
+
+
+def iter_images(root: Path):
+    paths = [root] if root.is_file() else root.rglob('*')
+    for path in sorted(paths):
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS:
+            yield path
+
+
+def output_format(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in {'.jpg', '.jpeg'}:
+        return 'JPEG'
+    if ext == '.png':
+        return 'PNG'
+    return 'WEBP'
+
+
+def dimension_steps(width: int, height: int, max_dimension: int):
+    largest = max(width, height)
+    start = min(largest, max_dimension)
+    if start <= MIN_DIMENSION:
+        return [start]
+
+    steps = []
+    current = start
+    while current >= MIN_DIMENSION:
+        steps.append(current)
+        current = int(current * 0.85)
+    if steps[-1] != MIN_DIMENSION:
+        steps.append(MIN_DIMENSION)
+    return steps
+
+
+def flatten_to_rgb(image: Image.Image) -> Image.Image:
+    if image.mode in {'RGBA', 'LA'} or (image.mode == 'P' and 'transparency' in image.info):
+        rgba = image.convert('RGBA')
+        background = Image.new('RGB', rgba.size, (255, 255, 255))
+        background.paste(rgba, mask=rgba.getchannel('A'))
+        return background
+    return image.convert('RGB')
+
+
+def save_candidate(source: Image.Image, target: Path, fmt: str, max_dimension: int, quality: int | None):
+    image = source.copy()
+    if max(image.size) > max_dimension:
+        image.thumbnail((max_dimension, max_dimension), RESAMPLE)
+
+    if fmt == 'JPEG':
+        flatten_to_rgb(image).save(
+            target,
+            format='JPEG',
+            quality=quality,
+            optimize=True,
+            progressive=True,
+        )
+    elif fmt == 'WEBP':
+        image.save(target, format='WEBP', quality=quality, method=6)
+    else:
+        image.save(target, format='PNG', optimize=True, compress_level=9)
+
+
+def optimize_one(path: Path, max_bytes: int, max_dimension: int) -> OptimizeResult:
+    original_size = path.stat().st_size
+    if original_size <= max_bytes:
+        return OptimizeResult('already_small', original_size, original_size)
+
+    tmp = path.with_name(f'.{path.name}.optimize-tmp{path.suffix}')
+    best = path.with_name(f'.{path.name}.optimize-best{path.suffix}')
+
+    try:
+        with Image.open(path) as opened:
+            opened.load()
+            if getattr(opened, 'is_animated', False):
+                return OptimizeResult('skipped', original_size, original_size, 'animated image')
+
+            fmt = output_format(path)
+            source = ImageOps.exif_transpose(opened)
+            qualities: list[int | None] = [None] if fmt == 'PNG' else list(QUALITY_VALUES)
+            best_size = original_size
+
+            for max_dim in dimension_steps(*source.size, max_dimension):
+                for quality in qualities:
+                    save_candidate(source, tmp, fmt, max_dim, quality)
+                    candidate_size = tmp.stat().st_size
+
+                    if candidate_size < best_size:
+                        shutil.copy2(tmp, best)
+                        best_size = candidate_size
+
+                    if candidate_size <= max_bytes:
+                        tmp.replace(path)
+                        if best.exists():
+                            best.unlink()
+                        return OptimizeResult('optimized', original_size, candidate_size)
+
+            if best.exists() and best_size < original_size:
+                best.replace(path)
+                status = 'optimized_over_target' if best_size > max_bytes else 'optimized'
+                return OptimizeResult(status, original_size, best_size)
+
+            return OptimizeResult('kept_original', original_size, original_size, 'no smaller candidate')
+    except UnidentifiedImageError:
+        return OptimizeResult('skipped', original_size, original_size, 'unidentified image')
+    except OSError as exc:
+        return OptimizeResult('skipped', original_size, original_size, str(exc))
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+        if best.exists():
+            best.unlink()
+
+
+def human_size(size: int) -> str:
+    return f'{size / 1024:.1f}KB'
+
+
+def relative(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Optimize oversized web images in-place')
+    parser.add_argument('path', help='Image file or directory to scan')
+    parser.add_argument('--max-kb', type=int, default=DEFAULT_MAX_KB, help='Target max size per image')
+    parser.add_argument(
+        '--max-dimension',
+        type=int,
+        default=DEFAULT_MAX_DIMENSION,
+        help='Initial long-edge resize limit for oversized images',
+    )
+    args = parser.parse_args()
+
+    root = Path(args.path).resolve()
+    if not root.exists():
+        raise SystemExit(f'path not found: {root}')
+    if args.max_kb <= 0:
+        print('IMAGE_OPTIMIZATION_DISABLED')
+        return
+
+    max_bytes = args.max_kb * 1024
+    optimized = 0
+    over_target = 0
+    skipped = 0
+
+    for image_path in iter_images(root):
+        result = optimize_one(image_path, max_bytes, args.max_dimension)
+        rel = relative(image_path, root if root.is_dir() else root.parent)
+
+        if result.status == 'optimized':
+            optimized += 1
+            print(f'IMAGE_OPTIMIZED {rel} {human_size(result.original_size)} -> {human_size(result.final_size)}')
+        elif result.status == 'optimized_over_target':
+            optimized += 1
+            over_target += 1
+            print(
+                f'IMAGE_OPTIMIZED_OVER_TARGET {rel} '
+                f'{human_size(result.original_size)} -> {human_size(result.final_size)}',
+                file=sys.stderr,
+            )
+        elif result.status == 'skipped':
+            skipped += 1
+            print(f'IMAGE_OPTIMIZATION_SKIPPED {rel}: {result.reason}', file=sys.stderr)
+
+    if optimized or over_target or skipped:
+        print(f'IMAGE_OPTIMIZATION_DONE optimized={optimized} over_target={over_target} skipped={skipped}')
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/github-pages-publisher/skills/github-pages-publisher/scripts/publish_static.py
+++ b/plugins/github-pages-publisher/skills/github-pages-publisher/scripts/publish_static.py
@@ -3,6 +3,8 @@ import argparse, os, re, shutil, subprocess, sys, tempfile
 from datetime import datetime
 from pathlib import Path
 
+DEFAULT_IMAGE_MAX_KB = 500
+
 
 def slugify(s: str) -> str:
     s = s.strip().lower()
@@ -15,12 +17,52 @@ def run(cmd, cwd=None):
     subprocess.run(cmd, cwd=cwd, check=True)
 
 
+def pillow_available() -> bool:
+    return subprocess.run(
+        [sys.executable, '-c', 'import PIL'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+def optimize_images(target: Path, max_kb: int, keep_large_images: bool):
+    if keep_large_images:
+        print('IMAGE_OPTIMIZATION_SKIPPED keep-large-images')
+        return
+    if max_kb <= 0:
+        print('IMAGE_OPTIMIZATION_DISABLED')
+        return
+
+    script = Path(__file__).resolve().with_name('optimize_images.py')
+    if not script.exists():
+        print(f'IMAGE_OPTIMIZATION_SKIPPED optimizer not found: {script}', file=sys.stderr)
+        return
+
+    cmd = None
+    if pillow_available():
+        cmd = [sys.executable, str(script), str(target), '--max-kb', str(max_kb)]
+    else:
+        uv = shutil.which('uv')
+        if uv:
+            cmd = [uv, 'run', '--quiet', '--with', 'pillow', 'python3', str(script), str(target), '--max-kb', str(max_kb)]
+
+    if cmd:
+        status = subprocess.run(cmd)
+        if status.returncode != 0:
+            print('IMAGE_OPTIMIZATION_SKIPPED optimizer failed; publishing originals', file=sys.stderr)
+        return
+
+    print('IMAGE_OPTIMIZATION_SKIPPED Pillow unavailable; publishing originals', file=sys.stderr)
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--source', required=True, help='Path to built static site folder or single html file')
     ap.add_argument('--slug', required=True)
     ap.add_argument('--date', help='ISO date, default today')
     ap.add_argument('--message', help='Commit message')
+    ap.add_argument('--image-max-kb', type=int, default=DEFAULT_IMAGE_MAX_KB, help='Target max size per raster image')
+    ap.add_argument('--keep-large-images', action='store_true', help='Publish original images without optimization')
     args = ap.parse_args()
 
     token = os.environ['GHPAGES_TOKEN']
@@ -56,6 +98,8 @@ def main():
                     shutil.copy2(item, dest)
         else:
             shutil.copy2(src, target / 'index.html')
+
+        optimize_images(target, args.image_max_kb, args.keep_large_images)
 
         if not (target / 'index.html').exists():
             raise SystemExit('index.html not found in published artifact')

--- a/plugins/sourcecraft-publisher/.claude-plugin/plugin.json
+++ b/plugins/sourcecraft-publisher/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sourcecraft-publisher",
   "version": "1.0.0",
-  "description": "Publish static page artifacts to SourceCraft Sites (Yandex infrastructure) with year/month directory layout",
+  "description": "Publish static page artifacts to SourceCraft Sites (Yandex infrastructure) with year/month directory layout and optional image optimization",
   "author": {
     "name": "Polyakov"
   }

--- a/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/SKILL.md
+++ b/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sourcecraft-publisher
-description: Publish static page artifacts to SourceCraft Sites (Yandex infrastructure, works in Russia). Use when a static page/React artifact needs to be deployed to SourceCraft under YYYY/YYYY-MM/page-slug directory layout.
+description: Publish static page artifacts to SourceCraft Sites (Yandex infrastructure, works in Russia), with advisory image optimization and an original-image path. Use when a static page/React artifact needs to be deployed to SourceCraft under YYYY/YYYY-MM/page-slug directory layout.
 ---
 
 # SourceCraft Publisher
@@ -55,15 +55,31 @@ Required: `SOURCECRAFT_TOKEN`, `SOURCECRAFT_REPO`, `SOURCECRAFT_SITE_URL`.
 ## Publishing command
 
 ```bash
-python3 scripts/publish_static.py --source <dir-or-html> --slug <name> [--date YYYY-MM-DD]
+python3 scripts/publish_static.py --source <dir-or-html> --slug <name> [--date YYYY-MM-DD] [--image-max-kb 500]
 ```
 
 The script:
 - Clones the SourceCraft repo (shallow)
 - Ensures `.sourcecraft/sites.yaml` config exists
 - Copies artifact into `YYYY/YYYY-MM/slug/`
+- Optimizes oversized `.jpg`, `.jpeg`, `.png`, and `.webp` images before commit
 - Commits and force-pushes
 - Prints the final public URL
+
+## Image optimization
+
+Image optimization is a recommendation, not a hard requirement. By default, the publishing script tries to keep each raster image under `500KB` by stripping metadata, recompressing, and resizing long edges when needed.
+
+Use `--image-max-kb <kb>` for a different target.
+Use `--keep-large-images` or `--image-max-kb 0` when the user explicitly needs original-size images (for example, a full-resolution infographic, map, or downloadable media asset).
+
+The original `--source` artifact is not changed. Optimization happens only after files are copied into the publish repo target directory. If Pillow/uv is unavailable or optimization fails, continue publishing originals and mention the warning.
+
+Manual console run for a prepared artifact:
+
+```bash
+uv run --with pillow python3 scripts/optimize_images.py <artifact-dir> --max-kb 500
+```
 
 ## Slug rules
 
@@ -80,6 +96,7 @@ Always return the final public URL:
 
 Before pushing, verify:
 - artifact has `index.html` entrypoint
+- oversized raster images are optimized when practical, unless original-size sharing is intentional
 - no absolute local paths in HTML/CSS
 - no secrets in files
 - all local assets reachable from the target folder

--- a/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/references/publish-checklist.md
+++ b/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/references/publish-checklist.md
@@ -4,6 +4,7 @@ Before push:
 - target path follows `YYYY/YYYY-MM/page-slug/`
 - artifact has `index.html`
 - all local assets remain reachable from that folder
+- oversized raster images are optimized when practical or intentionally kept large
 - no accidental absolute local paths
 - no secrets in files
 - `.sourcecraft/sites.yaml` exists in repo root

--- a/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/scripts/optimize_images.py
+++ b/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/scripts/optimize_images.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Optimize oversized raster images in-place before publishing."""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from PIL import Image, ImageOps, UnidentifiedImageError
+except ImportError as exc:
+    raise SystemExit(
+        'Pillow is required. Run with: '
+        'uv run --with pillow python3 scripts/optimize_images.py <path> --max-kb 500'
+    ) from exc
+
+
+IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp'}
+DEFAULT_MAX_KB = 500
+DEFAULT_MAX_DIMENSION = 1800
+MIN_DIMENSION = 640
+QUALITY_VALUES = range(85, 40, -5)
+RESAMPLE = getattr(getattr(Image, 'Resampling', Image), 'LANCZOS')
+
+
+@dataclass
+class OptimizeResult:
+    status: str
+    original_size: int
+    final_size: int
+    reason: str = ''
+
+
+def iter_images(root: Path):
+    paths = [root] if root.is_file() else root.rglob('*')
+    for path in sorted(paths):
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS:
+            yield path
+
+
+def output_format(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in {'.jpg', '.jpeg'}:
+        return 'JPEG'
+    if ext == '.png':
+        return 'PNG'
+    return 'WEBP'
+
+
+def dimension_steps(width: int, height: int, max_dimension: int):
+    largest = max(width, height)
+    start = min(largest, max_dimension)
+    if start <= MIN_DIMENSION:
+        return [start]
+
+    steps = []
+    current = start
+    while current >= MIN_DIMENSION:
+        steps.append(current)
+        current = int(current * 0.85)
+    if steps[-1] != MIN_DIMENSION:
+        steps.append(MIN_DIMENSION)
+    return steps
+
+
+def flatten_to_rgb(image: Image.Image) -> Image.Image:
+    if image.mode in {'RGBA', 'LA'} or (image.mode == 'P' and 'transparency' in image.info):
+        rgba = image.convert('RGBA')
+        background = Image.new('RGB', rgba.size, (255, 255, 255))
+        background.paste(rgba, mask=rgba.getchannel('A'))
+        return background
+    return image.convert('RGB')
+
+
+def save_candidate(source: Image.Image, target: Path, fmt: str, max_dimension: int, quality: int | None):
+    image = source.copy()
+    if max(image.size) > max_dimension:
+        image.thumbnail((max_dimension, max_dimension), RESAMPLE)
+
+    if fmt == 'JPEG':
+        flatten_to_rgb(image).save(
+            target,
+            format='JPEG',
+            quality=quality,
+            optimize=True,
+            progressive=True,
+        )
+    elif fmt == 'WEBP':
+        image.save(target, format='WEBP', quality=quality, method=6)
+    else:
+        image.save(target, format='PNG', optimize=True, compress_level=9)
+
+
+def optimize_one(path: Path, max_bytes: int, max_dimension: int) -> OptimizeResult:
+    original_size = path.stat().st_size
+    if original_size <= max_bytes:
+        return OptimizeResult('already_small', original_size, original_size)
+
+    tmp = path.with_name(f'.{path.name}.optimize-tmp{path.suffix}')
+    best = path.with_name(f'.{path.name}.optimize-best{path.suffix}')
+
+    try:
+        with Image.open(path) as opened:
+            opened.load()
+            if getattr(opened, 'is_animated', False):
+                return OptimizeResult('skipped', original_size, original_size, 'animated image')
+
+            fmt = output_format(path)
+            source = ImageOps.exif_transpose(opened)
+            qualities: list[int | None] = [None] if fmt == 'PNG' else list(QUALITY_VALUES)
+            best_size = original_size
+
+            for max_dim in dimension_steps(*source.size, max_dimension):
+                for quality in qualities:
+                    save_candidate(source, tmp, fmt, max_dim, quality)
+                    candidate_size = tmp.stat().st_size
+
+                    if candidate_size < best_size:
+                        shutil.copy2(tmp, best)
+                        best_size = candidate_size
+
+                    if candidate_size <= max_bytes:
+                        tmp.replace(path)
+                        if best.exists():
+                            best.unlink()
+                        return OptimizeResult('optimized', original_size, candidate_size)
+
+            if best.exists() and best_size < original_size:
+                best.replace(path)
+                status = 'optimized_over_target' if best_size > max_bytes else 'optimized'
+                return OptimizeResult(status, original_size, best_size)
+
+            return OptimizeResult('kept_original', original_size, original_size, 'no smaller candidate')
+    except UnidentifiedImageError:
+        return OptimizeResult('skipped', original_size, original_size, 'unidentified image')
+    except OSError as exc:
+        return OptimizeResult('skipped', original_size, original_size, str(exc))
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+        if best.exists():
+            best.unlink()
+
+
+def human_size(size: int) -> str:
+    return f'{size / 1024:.1f}KB'
+
+
+def relative(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Optimize oversized web images in-place')
+    parser.add_argument('path', help='Image file or directory to scan')
+    parser.add_argument('--max-kb', type=int, default=DEFAULT_MAX_KB, help='Target max size per image')
+    parser.add_argument(
+        '--max-dimension',
+        type=int,
+        default=DEFAULT_MAX_DIMENSION,
+        help='Initial long-edge resize limit for oversized images',
+    )
+    args = parser.parse_args()
+
+    root = Path(args.path).resolve()
+    if not root.exists():
+        raise SystemExit(f'path not found: {root}')
+    if args.max_kb <= 0:
+        print('IMAGE_OPTIMIZATION_DISABLED')
+        return
+
+    max_bytes = args.max_kb * 1024
+    optimized = 0
+    over_target = 0
+    skipped = 0
+
+    for image_path in iter_images(root):
+        result = optimize_one(image_path, max_bytes, args.max_dimension)
+        rel = relative(image_path, root if root.is_dir() else root.parent)
+
+        if result.status == 'optimized':
+            optimized += 1
+            print(f'IMAGE_OPTIMIZED {rel} {human_size(result.original_size)} -> {human_size(result.final_size)}')
+        elif result.status == 'optimized_over_target':
+            optimized += 1
+            over_target += 1
+            print(
+                f'IMAGE_OPTIMIZED_OVER_TARGET {rel} '
+                f'{human_size(result.original_size)} -> {human_size(result.final_size)}',
+                file=sys.stderr,
+            )
+        elif result.status == 'skipped':
+            skipped += 1
+            print(f'IMAGE_OPTIMIZATION_SKIPPED {rel}: {result.reason}', file=sys.stderr)
+
+    if optimized or over_target or skipped:
+        print(f'IMAGE_OPTIMIZATION_DONE optimized={optimized} over_target={over_target} skipped={skipped}')
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/scripts/publish_static.py
+++ b/plugins/sourcecraft-publisher/skills/sourcecraft-publisher/scripts/publish_static.py
@@ -11,6 +11,7 @@ import argparse, os, re, shutil, subprocess, sys, tempfile
 from datetime import datetime
 from pathlib import Path
 
+DEFAULT_IMAGE_MAX_KB = 500
 SITES_YAML = """\
 site:
   root: "."
@@ -29,12 +30,52 @@ def run(cmd, cwd=None):
     subprocess.run(cmd, cwd=cwd, check=True)
 
 
+def pillow_available() -> bool:
+    return subprocess.run(
+        [sys.executable, '-c', 'import PIL'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+def optimize_images(target: Path, max_kb: int, keep_large_images: bool):
+    if keep_large_images:
+        print('IMAGE_OPTIMIZATION_SKIPPED keep-large-images')
+        return
+    if max_kb <= 0:
+        print('IMAGE_OPTIMIZATION_DISABLED')
+        return
+
+    script = Path(__file__).resolve().with_name('optimize_images.py')
+    if not script.exists():
+        print(f'IMAGE_OPTIMIZATION_SKIPPED optimizer not found: {script}', file=sys.stderr)
+        return
+
+    cmd = None
+    if pillow_available():
+        cmd = [sys.executable, str(script), str(target), '--max-kb', str(max_kb)]
+    else:
+        uv = shutil.which('uv')
+        if uv:
+            cmd = [uv, 'run', '--quiet', '--with', 'pillow', 'python3', str(script), str(target), '--max-kb', str(max_kb)]
+
+    if cmd:
+        status = subprocess.run(cmd)
+        if status.returncode != 0:
+            print('IMAGE_OPTIMIZATION_SKIPPED optimizer failed; publishing originals', file=sys.stderr)
+        return
+
+    print('IMAGE_OPTIMIZATION_SKIPPED Pillow unavailable; publishing originals', file=sys.stderr)
+
+
 def main():
     ap = argparse.ArgumentParser(description='Publish to SourceCraft Sites')
     ap.add_argument('--source', required=True, help='Path to built static site folder or single html file')
     ap.add_argument('--slug', required=True, help='Page slug (lowercase, hyphens)')
     ap.add_argument('--date', help='ISO date, default today')
     ap.add_argument('--message', help='Commit message')
+    ap.add_argument('--image-max-kb', type=int, default=DEFAULT_IMAGE_MAX_KB, help='Target max size per raster image')
+    ap.add_argument('--keep-large-images', action='store_true', help='Publish original images without optimization')
     args = ap.parse_args()
 
     token = os.environ['SOURCECRAFT_TOKEN']
@@ -89,6 +130,8 @@ def main():
                     shutil.copy2(item, dest)
         else:
             shutil.copy2(src, target / 'index.html')
+
+        optimize_images(target, args.image_max_kb, args.keep_large_images)
 
         if not (target / 'index.html').exists():
             raise SystemExit('index.html not found in published artifact')


### PR DESCRIPTION
## What changed

- Added advisory image optimization to the SourceCraft and GitHub Pages publisher scripts.
- Added `optimize_images.py` helpers for `.jpg`, `.jpeg`, `.png`, and `.webp` assets with a default `500KB` target.
- Preserved the original-image publishing path with `--keep-large-images` and `--image-max-kb 0`.
- Updated publisher skill instructions, checklists, plugin metadata, marketplace descriptions, and `.gitignore` for `.claude/`.

## Why

Publisher outputs should prefer web-sized images for normal static page publishing, while still allowing full-resolution assets when that is the explicit intent.

## Validation

- `python3 -m py_compile` for the changed publisher scripts.
- `python3 -m json.tool` for marketplace and plugin metadata.
- `git diff --check` / `git diff --cached --check`.
- `publish_static.py --help` for both publishers.
- Manual optimizer smoke test on a generated JPEG: about `4.4MB -> 45KB` with a `50KB` target.

Real SourceCraft/GitHub Pages publishing was not run.
