### PR TITLE
Avoid PDF deps for non-PDF knowledge sources

### DIFF
--- a/plugins/knowledge-compiler/skills/knowledge-compiler/config/README.md
+++ b/plugins/knowledge-compiler/skills/knowledge-compiler/config/README.md
@@ -20,7 +20,7 @@ sh scripts/doctor.sh
 
 Минимум: `uv`. Python-зависимости объявлены в заголовках `scripts/*.py` и ставятся/кешируются через `uv run --script`.
 
-Для PDF желательно `pdftotext` из poppler. Запасные PDF-пакеты `pdfminer.six` и `PyPDF2` объявлены в `extract_source.py` и подтягиваются через `uv`.
+Для PDF желательно `pdftotext` из poppler. Запасные PDF-пакеты изолированы в отдельных помощниках: `extract_pypdf.py` объявляет `PyPDF2`, а `extract_pdfminer.py` объявляет `pdfminer.six`. Они запускаются только после того, как вход уже определён как PDF и `pdftotext` не сработал.
 
 EPUB разбирается стандартной библиотекой Python по `META-INF/container.xml`, OPF manifest и spine. Это менее тяжёлый путь без `ebooklib`/`lxml`. Скрипт также читает OPF `title`/`creator` и оглавление из `toc.ncx` или `nav.xhtml`; файл с расширением `.zip` принимается, если внутри настоящий EPUB-контейнер.
 

--- a/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_pdfminer.py
+++ b/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_pdfminer.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "pdfminer.six>=20231228",
+# ]
+# ///
+"""pdfminer.six PDF extraction helper. Used only after a source is known to be PDF."""
+
+from __future__ import annotations
+
+import sys
+
+from pdfminer.high_level import extract_text
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: extract_pdfminer.py <pdf-path>", file=sys.stderr)
+        return 2
+    text = extract_text(sys.argv[1])
+    if not text.strip():
+        return 1
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_pypdf.py
+++ b/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_pypdf.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "PyPDF2>=3.0.0",
+# ]
+# ///
+"""PyPDF2 PDF extraction helper. Used only after a source is known to be PDF."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import PyPDF2
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    count_pages = False
+    if args and args[0] == "--count-pages":
+        count_pages = True
+        args = args[1:]
+    if len(args) != 1:
+        print("Usage: extract_pypdf.py [--count-pages] <pdf-path>", file=sys.stderr)
+        return 2
+
+    path = Path(args[0])
+    with path.open("rb") as f:
+        reader = PyPDF2.PdfReader(f)
+        if count_pages:
+            print(len(reader.pages))
+            return 0
+        parts = []
+        for page in reader.pages:
+            parts.append(page.extract_text() or "")
+    text = "\n\n".join(parts)
+    if not text.strip():
+        return 1
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_source.py
+++ b/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_source.py
@@ -120,7 +120,7 @@ def extract_pdf(path: Path, mode: str, script_dir: Path) -> tuple[str, str, list
 
 
 def run_uv_helper(helper: Path, *args: str, timeout: int) -> str | None:
-    uv = shutil.which("uv")
+    uv = os.environ.get("UV") or shutil.which("uv")
     if not uv:
         return None
     text = run_text_command([uv, "run", "--script", str(helper), *args], timeout=timeout)

--- a/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_source.py
+++ b/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_source.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
-# dependencies = [
-#   "pdfminer.six>=20231228",
-#   "PyPDF2>=3.0.0",
-# ]
 # ///
 """Extract PDF/EPUB/TXT/Markdown into a resumable local job directory."""
 
@@ -110,41 +106,29 @@ def extract_pdf(path: Path, mode: str, script_dir: Path) -> tuple[str, str, list
         if text:
             return text, "pdftotext", warnings
 
-    try:
-        import PyPDF2
+    text = run_uv_helper(script_dir / "extract_pypdf.py", str(path), timeout=180)
+    if text:
+        return text, "PyPDF2", warnings
 
-        parts = []
-        with path.open("rb") as f:
-            reader = PyPDF2.PdfReader(f)
-            for page in reader.pages:
-                parts.append(page.extract_text() or "")
-        text = "\n\n".join(parts)
-        if text.strip():
-            return text, "PyPDF2", warnings
-    except Exception:
-        pass
-
-    try:
-        from pdfminer.high_level import extract_text
-
-        text = extract_text(str(path))
-        if text.strip():
-            return text, "pdfminer.six", warnings
-    except Exception:
-        pass
+    text = run_uv_helper(script_dir / "extract_pdfminer.py", str(path), timeout=180)
+    if text:
+        return text, "pdfminer.six", warnings
 
     raise SystemExit(
         "Could not extract PDF text. Install poppler pdftotext, PyPDF2, pdfminer.six, or docling."
     )
 
 
-def extract_with_docling(path: Path, script_dir: Path) -> str | None:
+def run_uv_helper(helper: Path, *args: str, timeout: int) -> str | None:
     uv = shutil.which("uv")
     if not uv:
         return None
-    helper = script_dir / "extract_docling.py"
-    text = run_text_command([uv, "run", "--script", str(helper), str(path)], timeout=60 * 30)
+    text = run_text_command([uv, "run", "--script", str(helper), *args], timeout=timeout)
     return text if text and text.strip() else None
+
+
+def extract_with_docling(path: Path, script_dir: Path) -> str | None:
+    return run_uv_helper(script_dir / "extract_docling.py", str(path), timeout=60 * 30)
 
 
 class HTMLTextExtractor(html.parser.HTMLParser):
@@ -346,13 +330,14 @@ def count_pdf_pages(path: Path) -> int:
                         return int(line.split(":", 1)[1].strip())
                     except ValueError:
                         pass
-    try:
-        import PyPDF2
-
-        with path.open("rb") as f:
-            return len(PyPDF2.PdfReader(f).pages)
-    except Exception:
-        return 0
+    helper = Path(__file__).resolve().parent / "extract_pypdf.py"
+    text = run_uv_helper(helper, "--count-pages", str(path), timeout=60)
+    if text:
+        try:
+            return int(text.strip())
+        except ValueError:
+            return 0
+    return 0
 
 
 def count_epub_spine(path: Path) -> int:

--- a/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/tests/test_non_pdf_no_pdf_deps.sh
+++ b/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/tests/test_non_pdf_no_pdf_deps.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -e
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+REAL_UV="$(command -v uv)"
+mkdir -p "$TMP_DIR/bin"
+cat > "$TMP_DIR/bin/uv" <<EOF
+#!/bin/sh
+if [ "\$1" = "run" ]; then
+    shift
+    exec "$REAL_UV" run --no-index --no-cache "\$@"
+fi
+exec "$REAL_UV" "\$@"
+EOF
+chmod +x "$TMP_DIR/bin/uv"
+
+# Non-PDF formats must not resolve PDF-only uv dependencies. The wrapper forces
+# prepare_source.sh to run uv with --no-index and --no-cache, so this fails before
+# Python starts if extract_source.py declares pdfminer/PyPDF2 at top level.
+PATH="$TMP_DIR/bin:$PATH" \
+KNOWLEDGE_COMPILER_CACHE_DIR="$TMP_DIR/cache" \
+    sh "$SKILL_DIR/scripts/prepare_source.sh" \
+    --input "$TEST_DIR/fixtures/sample-source.txt" \
+    --job-id text-no-pdf-deps \
+    >/dev/null
+
+test -s "$TMP_DIR/cache/jobs/text-no-pdf-deps/source.txt"
+test -s "$TMP_DIR/cache/jobs/text-no-pdf-deps/metadata.json"
+
+uv run python - "$TMP_DIR/cache/jobs/text-no-pdf-deps/metadata.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+meta = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert meta["format"] == "text"
+assert meta["extraction_method"] == "plain-text"
+PY

--- a/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/tests/test_uv_override_helpers.sh
+++ b/plugins/knowledge-compiler/skills/knowledge-compiler/scripts/tests/test_uv_override_helpers.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_UV="$TMP_DIR/custom-uv"
+cat > "$FAKE_UV" <<'EOF'
+#!/bin/sh
+test "$1" = "run"
+test "$2" = "--script"
+printf 'helper=%s arg=%s\n' "$3" "$4"
+EOF
+chmod +x "$FAKE_UV"
+
+uv run python - "$SKILL_DIR/scripts/extract_source.py" "$FAKE_UV" <<'PY'
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+module_path = Path(sys.argv[1])
+fake_uv = sys.argv[2]
+spec = importlib.util.spec_from_file_location("extract_source", module_path)
+mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mod)
+
+os.environ["UV"] = fake_uv
+os.environ["PATH"] = "/usr/bin:/bin"
+result = mod.run_uv_helper(Path("/tmp/helper.py"), "payload", timeout=10)
+assert result is not None
+assert result.strip() == "helper=/tmp/helper.py arg=payload", result
+PY


### PR DESCRIPTION
## Summary
- remove PDF-only uv dependencies from extract_source.py so TXT/Markdown/EPUB can run without resolving PyPDF2/pdfminer.six
- move PyPDF2 and pdfminer.six fallbacks into PDF-only helper scripts
- add a regression test that runs prepare_source.sh for TXT through uv --no-index --no-cache

## Review finding
Addresses Codex review finding: "Avoid forcing PDF deps for non-PDF sources".

## Tests
- sh plugins/knowledge-compiler/skills/knowledge-compiler/scripts/tests/run.sh
- uv run python -m py_compile plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_source.py plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_docling.py plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_pypdf.py plugins/knowledge-compiler/skills/knowledge-compiler/scripts/extract_pdfminer.py plugins/knowledge-compiler/skills/knowledge-compiler/scripts/outline_scout.py plugins/knowledge-compiler/skills/knowledge-compiler/scripts/segment_text.py plugins/knowledge-compiler/skills/knowledge-compiler/scripts/quality_gate.py
- sh -n knowledge-compiler shell scripts
- git diff --check