### PR TITLE
[codex] Исправить запуск скиллов из рабочей копии

### DIFF
--- a/plugins/telegram-channel-parser/skills/telegram-channel-parser/SKILL.md
+++ b/plugins/telegram-channel-parser/skills/telegram-channel-parser/SKILL.md
@@ -13,6 +13,17 @@ description: |
 
 Парсинг публичных Telegram-каналов через веб-превью (t.me/s/). Без API-ключей, без MTProto, zero config.
 
+## Перед запуском
+
+Перед любым запуском скриптов создай рабочую копию скилла в `/home/claude/telegram-channel-parser` и работай уже из неё:
+
+```bash
+bash scripts/prepare_runtime.sh
+cd /home/claude/telegram-channel-parser
+```
+
+`prepare_runtime.sh` копирует скилл и, если есть `config/.env`, нормализует его через `sed -i`: некавыченные значения с пробелами или кириллицей оборачиваются в кавычки в рабочей копии.
+
 ## Config
 
 Никаких токенов не требуется. Для дайджестов — скопировать `.env.example`:
@@ -29,10 +40,10 @@ cp config/.env.example config/.env
 TG_CATEGORIES=ai,crypto         # реестр доступных категорий
 TG_DEFAULT_CATEGORY=ai           # дефолтная при запросе "дайджест"
 
-TG_CHANNELS_AI_LABEL=AI и технологии
+TG_CHANNELS_AI_LABEL="AI и технологии"
 TG_CHANNELS_AI=countwithsasha,evilfreelancer,...
 
-TG_CHANNELS_CRYPTO_LABEL=Криптовалюты
+TG_CHANNELS_CRYPTO_LABEL="Криптовалюты"
 TG_CHANNELS_CRYPTO=channel1,channel2
 ```
 

--- a/plugins/telegram-channel-parser/skills/telegram-channel-parser/config/README.md
+++ b/plugins/telegram-channel-parser/skills/telegram-channel-parser/config/README.md
@@ -11,6 +11,15 @@ cp config/.env.example config/.env
 
 Готово — дайджест AI-каналов работает из коробки.
 
+Перед запуском скриптов из установленного скилла сначала создайте рабочую копию:
+
+```bash
+bash scripts/prepare_runtime.sh
+cd /home/claude/telegram-channel-parser
+```
+
+Подготовка также чинит `config/.env` в рабочей копии через `sed -i`: значения с пробелами или кириллицей должны быть в кавычках.
+
 ## Категории дайджестов
 
 `.env` содержит **реестр категорий** — агент читает его и знает какие дайджесты доступны.
@@ -23,11 +32,11 @@ TG_CATEGORIES=ai,crypto,news
 TG_DEFAULT_CATEGORY=ai
 
 # Категория: AI
-TG_CHANNELS_AI_LABEL=AI и технологии
+TG_CHANNELS_AI_LABEL="AI и технологии"
 TG_CHANNELS_AI=countwithsasha,evilfreelancer,...
 
 # Категория: Crypto
-TG_CHANNELS_CRYPTO_LABEL=Криптовалюты
+TG_CHANNELS_CRYPTO_LABEL="Криптовалюты"
 TG_CHANNELS_CRYPTO=channel1,channel2
 ```
 

--- a/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/common.sh
+++ b/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/common.sh
@@ -12,6 +12,9 @@ TG_REQUEST_DELAY="1.5"
 
 load_config() {
     if [ -f "$CONFIG_FILE" ]; then
+        if [ -f "$SCRIPT_DIR/sanitize_env.sh" ]; then
+            bash "$SCRIPT_DIR/sanitize_env.sh" "$CONFIG_FILE"
+        fi
         . "$CONFIG_FILE"
     fi
 }

--- a/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/prepare_runtime.sh
+++ b/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/prepare_runtime.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copy the skill to a writable runtime directory before running scripts.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_NAME="$(basename "$SKILL_DIR")"
+RUN_DIR="${1:-/home/claude/$SKILL_NAME}"
+RUN_PARENT="$(dirname "$RUN_DIR")"
+RUN_BASE="$(basename "$RUN_DIR")"
+
+mkdir -p "$RUN_PARENT"
+RUN_PARENT="$(cd "$RUN_PARENT" && pwd)"
+RUN_DIR="$RUN_PARENT/$RUN_BASE"
+
+if [ "$SKILL_DIR" != "$RUN_DIR" ]; then
+    mkdir -p "$RUN_DIR"
+    cp -R "$SKILL_DIR"/. "$RUN_DIR"/
+fi
+
+if [ -f "$RUN_DIR/config/.env" ]; then
+    bash "$RUN_DIR/scripts/sanitize_env.sh" "$RUN_DIR/config/.env"
+fi
+
+printf '%s\n' "$RUN_DIR"

--- a/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/sanitize_env.sh
+++ b/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/sanitize_env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Quote unquoted .env values that contain spaces before shell sourcing.
+
+set -e
+
+ENV_FILE="${1:-config/.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+    exit 0
+fi
+
+SED_SKIP_COMMENT='/^[[:space:]]*#/b'
+SED_SKIP_EMPTY='/^[[:space:]]*$/b'
+SED_QUOTE_VALUE='s/^([[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*)([^"'\''#][^#]*[[:space:]][^#]*)([[:space:]]*(#.*)?)$/\1"\3"\4/'
+
+if sed --version >/dev/null 2>&1; then
+    sed -i -E -e "$SED_SKIP_COMMENT" -e "$SED_SKIP_EMPTY" -e "$SED_QUOTE_VALUE" "$ENV_FILE"
+else
+    sed -i '' -E -e "$SED_SKIP_COMMENT" -e "$SED_SKIP_EMPTY" -e "$SED_QUOTE_VALUE" "$ENV_FILE"
+fi

--- a/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/tests/run.sh
+++ b/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/tests/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+bash "$TEST_DIR/test_config_loader.sh"
+
+echo "telegram-channel-parser tests passed"

--- a/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/tests/test_config_loader.sh
+++ b/plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/tests/test_config_loader.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/../.." && pwd)"
+COMMON_SH="$SKILL_DIR/scripts/common.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tg_config_test.XXXXXX")"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT TERM
+
+cat > "$TMP_DIR/.env" <<'EOF'
+TG_CATEGORIES=ai
+TG_DEFAULT_CATEGORY=ai
+TG_CHANNELS_AI_LABEL=AI и технологии
+TG_CHANNELS_AI=countwithsasha,evilfreelancer
+EOF
+
+# shellcheck disable=SC1090
+. "$COMMON_SH"
+
+SCRIPT_DIR="$SKILL_DIR/scripts"
+CONFIG_FILE="$TMP_DIR/.env"
+CACHE_DIR="$TMP_DIR/cache"
+
+load_config >/dev/null
+
+[ "$TG_CATEGORIES" = "ai" ]
+[ "$TG_DEFAULT_CATEGORY" = "ai" ]
+[ "$TG_CHANNELS_AI_LABEL" = "AI и технологии" ]
+[ "$TG_CHANNELS_AI" = "countwithsasha,evilfreelancer" ]
+grep -q '^TG_CHANNELS_AI_LABEL="AI и технологии"$' "$TMP_DIR/.env"

--- a/plugins/x-research/skills/x-research/SKILL.md
+++ b/plugins/x-research/skills/x-research/SKILL.md
@@ -13,6 +13,17 @@ description: |
 
 Research X/Twitter via xAI Grok API. Grok's `x_search` tool searches X in real-time and returns synthesized analysis with citations.
 
+## Перед запуском
+
+Перед любым запуском скриптов создай рабочую копию скилла в `/home/claude/x-research` и работай уже из неё:
+
+```bash
+sh scripts/prepare_runtime.sh
+cd /home/claude/x-research
+```
+
+`prepare_runtime.sh` копирует скилл и, если есть `config/.env`, нормализует его через `sed -i`: некавыченные значения с пробелами оборачиваются в кавычки в рабочей копии. Не выводи содержимое `.env` в ответ; при ошибке формата подскажи пользователю, какие строки нужно заключить в кавычки.
+
 ## Config
 
 Get an xAI API key at [console.x.ai](https://console.x.ai/), then:
@@ -21,7 +32,7 @@ cp config/.env.example config/.env
 ```
 
 Edit `config/.env`: paste your key into `XAI_API_KEY`, configure accounts and topics.
-Quote any value that contains spaces so the file stays shell-compatible.
+Quote any value that contains spaces so the file stays shell-compatible. Шаг подготовки также чинит некавыченные значения с пробелами в скопированном `.env`.
 
 **Without `.env`:** skill works with explicit `--accounts`, `--query`, `--topics`.
 

--- a/plugins/x-research/skills/x-research/config/README.md
+++ b/plugins/x-research/skills/x-research/config/README.md
@@ -18,6 +18,15 @@ Edit `.env` and paste your key into `XAI_API_KEY`.
 Important: keep `.env` shell-compatible. If a value contains spaces, wrap the whole value in quotes.
 Some runners use `. config/.env`, and unquoted values such as `Claude Code` will be treated as commands.
 
+Перед запуском скриптов из установленного скилла сначала создайте рабочую копию:
+
+```bash
+sh scripts/prepare_runtime.sh
+cd /home/claude/x-research
+```
+
+Подготовка также запускает `sed -i` для скопированного `config/.env` и заключает некавыченные значения с пробелами в кавычки. Не выводите содержимое `.env` при разборе ошибок настройки; указывайте пользователю только имена переменных, которые нужно исправить.
+
 ## 3. Configure accounts & topics
 
 Edit `.env` to add X accounts you want to follow and topics you care about.

--- a/plugins/x-research/skills/x-research/scripts/common.sh
+++ b/plugins/x-research/skills/x-research/scripts/common.sh
@@ -30,6 +30,9 @@ check_python3() {
 load_config() {
     check_python3
     if [ -f "$CONFIG_FILE" ]; then
+        if [ -f "$SCRIPT_DIR/sanitize_env.sh" ]; then
+            sh "$SCRIPT_DIR/sanitize_env.sh" "$CONFIG_FILE"
+        fi
         _exports_file=$(mktemp "${TMPDIR:-/tmp}/xr_env.XXXXXX")
         if ! python3 - "$CONFIG_FILE" > "$_exports_file" <<'PY'
 import pathlib

--- a/plugins/x-research/skills/x-research/scripts/prepare_runtime.sh
+++ b/plugins/x-research/skills/x-research/scripts/prepare_runtime.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copy the skill to a writable runtime directory before running scripts.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_NAME="$(basename "$SKILL_DIR")"
+RUN_DIR="${1:-/home/claude/$SKILL_NAME}"
+RUN_PARENT="$(dirname "$RUN_DIR")"
+RUN_BASE="$(basename "$RUN_DIR")"
+
+mkdir -p "$RUN_PARENT"
+RUN_PARENT="$(cd "$RUN_PARENT" && pwd)"
+RUN_DIR="$RUN_PARENT/$RUN_BASE"
+
+if [ "$SKILL_DIR" != "$RUN_DIR" ]; then
+    mkdir -p "$RUN_DIR"
+    cp -R "$SKILL_DIR"/. "$RUN_DIR"/
+fi
+
+if [ -f "$RUN_DIR/config/.env" ]; then
+    sh "$RUN_DIR/scripts/sanitize_env.sh" "$RUN_DIR/config/.env"
+fi
+
+printf '%s\n' "$RUN_DIR"

--- a/plugins/x-research/skills/x-research/scripts/sanitize_env.sh
+++ b/plugins/x-research/skills/x-research/scripts/sanitize_env.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Quote unquoted .env values that contain spaces before any shell-style loading.
+
+set -e
+
+ENV_FILE="${1:-config/.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+    exit 0
+fi
+
+SED_SKIP_COMMENT='/^[[:space:]]*#/b'
+SED_SKIP_EMPTY='/^[[:space:]]*$/b'
+SED_QUOTE_VALUE='s/^([[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*)([^"'\''#][^#]*[[:space:]][^#]*)([[:space:]]*(#.*)?)$/\1"\3"\4/'
+
+if sed --version >/dev/null 2>&1; then
+    sed -i -E -e "$SED_SKIP_COMMENT" -e "$SED_SKIP_EMPTY" -e "$SED_QUOTE_VALUE" "$ENV_FILE"
+else
+    sed -i '' -E -e "$SED_SKIP_COMMENT" -e "$SED_SKIP_EMPTY" -e "$SED_QUOTE_VALUE" "$ENV_FILE"
+fi

--- a/plugins/x-research/skills/x-research/scripts/tests/test_config_loader.sh
+++ b/plugins/x-research/skills/x-research/scripts/tests/test_config_loader.sh
@@ -3,8 +3,8 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SKILL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-COMMON_SH="$SKILL_DIR/scripts/common.sh"
+REAL_SKILL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMMON_SH="$REAL_SKILL_DIR/scripts/common.sh"
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/xr_config_test.XXXXXX")
 
 cleanup() {
@@ -26,6 +26,7 @@ EOF
 # shellcheck disable=SC1090
 . "$COMMON_SH"
 
+SCRIPT_DIR="$REAL_SKILL_DIR/scripts"
 CONFIG_FILE="$TMP_DIR/.env"
 CACHE_DIR="$TMP_DIR/cache"
 RUNS_DIR="$CACHE_DIR/runs"
@@ -40,3 +41,5 @@ load_config >/dev/null
 [ "$X_TOPICS_ANTHROPIC" = "Claude,Anthropic,ClaudeCode,Claude Code" ]
 [ "$X_ACCOUNTS_OPENAI_LABEL" = "OpenAI ecosystem" ]
 [ "$X_ACCOUNTS_OPENAI" = "sama,OpenAI" ]
+grep -q '^X_TOPICS_OPENAI="GPT,ChatGPT,OpenAI,Codex,gpt 5.4"$' "$TMP_DIR/.env"
+grep -q '^X_TOPICS_ANTHROPIC="Claude,Anthropic,ClaudeCode,Claude Code"$' "$TMP_DIR/.env"


### PR DESCRIPTION
## Что изменено

- Добавлена подготовка рабочей копии Telegram-парсера и x-research в `/home/claude/<skill>` перед запуском скриптов.
- Добавлена нормализация `config/.env` через `sed -i`: некавыченные значения с пробелами или кириллицей заключаются в кавычки в рабочей копии.
- Telegram-парсер больше не ломается на некавыченных русских подписях категорий при загрузке `.env`.
- Для x-research сохранён безопасный разбор `.env`; добавлена правка файла перед чтением и тест на значения с пробелами.

## Проверки

- `bash plugins/telegram-channel-parser/skills/telegram-channel-parser/scripts/tests/run.sh`
- `sh plugins/x-research/skills/x-research/scripts/tests/run.sh`
- `git diff --cached --check`