### PR TITLE
fix(codex-review): pass reasoning effort to codex exec on init

### DIFF
--- a/plugins/codex-review/.claude-plugin/plugin.json
+++ b/plugins/codex-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review",
   "description": "Cross-agent review workflow: Claude implements, Codex reviews",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "Polyakov"
   },

--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -81,10 +81,20 @@ STATE_DIR="$(get_state_dir)"
 MAX_ITERATIONS="${MAX_ITER:-$CODEX_MAX_ITERATIONS}"
 SESSION_ID="$(get_effective_session_id)"
 
-# --- Build yolo flags (as array to avoid word splitting) ---
+# --- Build codex exec flags (as arrays to avoid word splitting) ---
 YOLO_FLAG=()
 if [[ "$CODEX_YOLO" == "true" ]]; then
     YOLO_FLAG=("--yolo")
+fi
+
+MODEL_FLAG=()
+if [[ -n "$CODEX_MODEL" ]]; then
+    MODEL_FLAG=("--model" "$CODEX_MODEL")
+fi
+
+REASONING_FLAG=()
+if [[ -n "$CODEX_REASONING_EFFORT" ]]; then
+    REASONING_FLAG=("-c" "model_reasoning_effort=\"$CODEX_REASONING_EFFORT\"")
 fi
 
 # --- Reviewer role prompt (reusable base) ---
@@ -362,13 +372,9 @@ cmd_init() {
     echo "Creating Codex session..." >&2
     printf '\033[1;33m>>> Monitor: tail -f %s\033[0m\n' "$log_file" >&2
 
-    local MODEL_FLAG=()
-    if [[ -n "$CODEX_MODEL" ]]; then
-        MODEL_FLAG=("--model" "$CODEX_MODEL")
-    fi
-
     CODEX_REVIEWER=1 codex exec \
         "${MODEL_FLAG[@]}" \
+        "${REASONING_FLAG[@]}" \
         "${YOLO_FLAG[@]}" \
         -o "$output_file" \
         "$prompt" </dev/null > "$log_file" 2>&1 || {
@@ -469,16 +475,6 @@ cmd_review() {
 
     echo "Sending $phase for review (iteration ${next_iteration}/${MAX_ITERATIONS})..." >&2
     printf '\033[1;33m>>> Monitor: tail -f %s\033[0m\n' "$log_file" >&2
-
-    local MODEL_FLAG=()
-    if [[ -n "$CODEX_MODEL" ]]; then
-        MODEL_FLAG=("--model" "$CODEX_MODEL")
-    fi
-
-    local REASONING_FLAG=()
-    if [[ -n "$CODEX_REASONING_EFFORT" ]]; then
-        REASONING_FLAG=("-c" "model_reasoning_effort=\"$CODEX_REASONING_EFFORT\"")
-    fi
 
     CODEX_REVIEWER=1 codex exec \
         "${MODEL_FLAG[@]}" \


### PR DESCRIPTION
## Problem

`CODEX_REASONING_EFFORT` from `.codex-review/config.env` is honored by `cmd_review` but not by `cmd_init`: init builds its own `MODEL_FLAG` and never passes `-c model_reasoning_effort=...`. Session creation therefore falls back to whatever `model_reasoning_effort` sits in the global `~/.codex/config.toml`.

Two effects when the two sources disagree:

1. **Silent drift** — the session is created at one reasoning effort, every review inside it runs at another. Nothing in the output says so.
2. **Hard failure** — if the global effort is unsupported by the pinned `CODEX_MODEL`, `init` fails while `plan` / `code` on the same config keep working.

## Repro

`~/.codex/config.toml`:
```toml
model_reasoning_effort = "ultra"
```
`.codex-review/config.env`:
```
CODEX_MODEL=gpt-5.5
CODEX_REASONING_EFFORT=xhigh
```
```
$ bash scripts/codex-review.sh init "task"
ERROR: Failed to create Codex session.
ERROR: {"type":"error","error":{"type":"invalid_request_error","code":"unsupported_value",
"message":"Unsupported value: 'max' is not supported with the 'gpt-5.5-...' model.
Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'."},"status":400}
```
`gpt-5.5` tops out at `xhigh`; the effort the user pinned in `config.env` never reaches the CLI. Same config, `code` phase: works, because that path passes the flag.

## Fix

`MODEL_FLAG` and `REASONING_FLAG` are now built once next to `YOLO_FLAG` and shared by both `codex exec` call sites, instead of being rebuilt per command. The two paths can no longer drift apart — which is the actual root cause here, not the missing flag itself.

Net: 13 insertions, 17 deletions; no behavior change for `plan` / `code`.

## Verification

- `sh plugins/codex-review/test/test-integration.sh` → 8 passed, 0 failed
- `sh plugins/codex-review/test/test-auto-approve-plan.sh` → same result as on unmodified `main` in my environment (Git Bash on Windows): one pre-existing failure in Test 12 (JSON-validity assertion), reproduced on a pristine checkout, unrelated to this change
- Manual: `init` with `CODEX_MODEL=gpt-5.6-terra` + `CODEX_REASONING_EFFORT=ultra` now logs `model: gpt-5.6-terra` / `reasoning effort: ultra` and creates the session

Version bumped 1.2.1 → 1.2.2, following 91730e9.

Happy to add a regression test with a fake `codex` on `PATH` asserting the recorded argv, if you want one in `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
