### PR TITLE
Add AI Studio API key authentication to Wordstat

### DIFF
--- a/plugins/yandex-wordstat/skills/yandex-wordstat/SKILL.md
+++ b/plugins/yandex-wordstat/skills/yandex-wordstat/SKILL.md
@@ -18,14 +18,14 @@ Analyze search demand and keyword statistics using Yandex Wordstat API.
 
 Скилл поддерживает два бэкенда:
 
-- **`cloud`** (рекомендуется) — Yandex Cloud Search API v2. Нужен `config/config.json` + service account key. Авторизация через IAM token (JWT с SA-ключа).
+- **`cloud`** (рекомендуется) — Yandex Cloud Search API v2. Проще всего настроить через API-ключ AI Studio (`YANDEX_AI_API_KEY`) и ID каталога; также поддерживается IAM token сервисного аккаунта.
 - **`legacy`** (deprecated) — старый Wordstat OAuth API. Нужен `YANDEX_WORDSTAT_TOKEN` в `config/.env`. Яндекс больше не подключает новых пользователей, но старые токены работают.
 
 **Auto-selection (cloud-first)**: cloud выигрывает на tie. Чтобы остаться на legacy явно — `YANDEX_WORDSTAT_BACKEND=legacy` в `config/.env`.
 
 Полная инструкция по настройке и troubleshooting: [config/README.md](config/README.md).
 
-**Миграция в облако**: когда Яндекс окончательно отключит legacy — удалите `YANDEX_WORDSTAT_TOKEN`, заполните `config/config.json` и `config/service_account_key.json`. Команды и аргументы скриптов не меняются.
+**Миграция в облако**: когда Яндекс окончательно отключит legacy — удалите `YANDEX_WORDSTAT_TOKEN`, заполните `config/config.json`, а API-ключ AI Studio сохраните как `YANDEX_AI_API_KEY` в `config/.env`. Команды и аргументы скриптов не меняются.
 
 ⚠️ **Cloud `dynamics` operator caveat**: при `--period weekly|monthly` cloud-бэкенд поддерживает только оператор `+`. Минус-слова, кавычки, группировки и точные формы работают только при `--period daily`. Скилл делает preflight-проверку и падает с понятной ошибкой до запроса. Подробнее — в README.
 

--- a/plugins/yandex-wordstat/skills/yandex-wordstat/config/README.md
+++ b/plugins/yandex-wordstat/skills/yandex-wordstat/config/README.md
@@ -4,7 +4,7 @@
 
 | Бэкенд    | Endpoint                                       | Авторизация               | Статус |
 |-----------|------------------------------------------------|---------------------------|--------|
-| `cloud`   | `searchapi.api.cloud.yandex.net/v2/wordstat/*` | IAM token (Service Account JWT) | Preview, актуальный |
+| `cloud`   | `searchapi.api.cloud.yandex.net/v2/wordstat/*` | AI Studio API key или IAM token | Preview, актуальный |
 | `legacy`  | `api.wordstat.yandex.net/v1/*`                 | OAuth Bearer              | Deprecated, новых пользователей не подключают |
 
 С 2026 года Яндекс перестал выдавать новые токены для legacy. Старые токены всё ещё работают (бесплатно), но новые установки скилла должны использовать `cloud`.
@@ -13,7 +13,7 @@
 
 ## Cloud mode (рекомендуется для новых установок)
 
-Нужен сервисный аккаунт в Яндекс.Облаке.
+Самый простой вариант — API-ключ AI Studio. Сервисный аккаунт и ручное получение IAM-токена для него не нужны.
 
 ### Шаг 1: Создайте каталог в Яндекс.Облаке
 1. Откройте https://console.yandex.cloud/
@@ -21,26 +21,20 @@
 3. Создайте **каталог** или используйте существующий
 4. Скопируйте **ID каталога** (`b1g...`) — он понадобится дальше
 
-### Шаг 2: Создайте сервисный аккаунт
-1. В консоли откройте ваш каталог
-2. Слева выберите **Сервисные аккаунты** (раздел IAM)
-3. Нажмите **Создать сервисный аккаунт**
-4. Имя: `wordstat-sa` (или любое)
-5. Нажмите **Создать**
+### Шаг 2: Создайте API-ключ AI Studio
+1. Откройте AI Studio в нужном каталоге.
+2. Создайте API-ключ со scope `yc.search-api.execute`.
+3. Убедитесь, что субъекту ключа назначена роль `search-api.webSearch.user` на каталог.
+4. Сохраните ключ в `config/.env`:
 
-### Шаг 3: Назначьте роль
-1. Откройте созданный сервисный аккаунт
-2. Назначьте роль `search-api.webSearch.user` (та же роль используется для Yandex Search API — см. yandex-search-api скилл)
+```dotenv
+YANDEX_AI_API_KEY=AQVN...
+YANDEX_WORDSTAT_BACKEND=cloud
+```
 
-### Шаг 4: Создайте ключ авторизации
-1. В сервисном аккаунте → **Авторизованные ключи** → **Создать**
-2. Скачайте JSON-файл
-3. Переименуйте в `service_account_key.json`
-4. Положите в `config/` (рядом с этим README)
+Файл `config/.env` должен иметь права `600` и не должен попадать в Git.
 
-> Файл секретный — он уже в `.gitignore`.
-
-### Шаг 5: Создайте config.json
+### Шаг 3: Создайте config.json
 ```bash
 cp config/config.example.json config/config.json
 ```
@@ -50,19 +44,31 @@ cp config/config.example.json config/config.json
 {
   "yandex_cloud_folder_id": "b1g_ваш_id_каталога",
   "auth": {
+    "mode": "api_key"
+  }
+}
+```
+
+### Шаг 4: Проверьте
+
+Первую проверку лучше делать бесплатным методом `GetRegionsTree`. Скрипты анализа запросов используют тарифицируемые методы Wordstat согласно актуальному тарифу Yandex Cloud.
+
+### Альтернатива: IAM сервисного аккаунта
+
+Старый способ остаётся рабочим. Создайте сервисный аккаунт с ролью `search-api.webSearch.user`, скачайте авторизованный JSON-ключ и используйте:
+
+```json
+{
+  "yandex_cloud_folder_id": "b1g_ваш_id_каталога",
+  "auth": {
+    "mode": "iam",
     "service_account_key_file": "config/service_account_key.json",
     "openssl_bin": "openssl"
   }
 }
 ```
 
-`auth.service_account_key_file` — путь к ключу. Относительные пути резолвятся от корня скилла, не от `config/`. Можно указать абсолютный путь.
-
-### Шаг 6: Проверьте
-```bash
-sh scripts/quota.sh
-```
-Должно вывести `Backend: cloud (auto: config.json present)` и список endpoints.
+Относительные пути резолвятся от корня скилла, не от `config/`.
 
 ### Если используете уже настроенный yandex-search-api
 Если у вас уже есть `service_account_key.json` для скилла `yandex-search-api`, схема `config.json` идентична — можно скопировать оба файла:
@@ -110,7 +116,8 @@ sh scripts/quota.sh
 2. **Cloud structurally configured** → `cloud`. Это значит:
    - `config/config.json` существует и валидно парсится
    - `yandex_cloud_folder_id` непустой
-   - `auth.service_account_key_file` резолвится в существующий читаемый файл
+   - для `auth.mode=api_key` задан `YANDEX_AI_API_KEY`
+   - для `auth.mode=iam` файл `auth.service_account_key_file` существует и читается
 3. **`YANDEX_WORDSTAT_TOKEN` задан** → `legacy`
 4. **Ничего не задано** → ошибка с ссылкой на этот README
 
@@ -119,7 +126,7 @@ sh scripts/quota.sh
 YANDEX_WORDSTAT_BACKEND=legacy
 ```
 
-**Selector делает только структурную проверку** — никаких сетевых запросов, никакой проверки IAM. Если SA-ключ битый или роль не назначена, ошибка появится при первом реальном API-запросе.
+**Selector делает только структурную проверку** — никаких сетевых запросов. Если API/SA-ключ битый, scope отсутствует или роль не назначена, ошибка появится при первом реальном API-запросе.
 
 ---
 
@@ -149,11 +156,12 @@ Legacy-бэкенд исторически принимает все опера�
 ## Troubleshooting
 
 ### `Wordstat API: Error` / `wordstat 401`
-- **Cloud**: SA-ключ битый или истёк → пересоздайте ключ; либо роль `search-api.webSearch.user` не назначена → назначьте.
+- **Cloud API key**: ключ неверен/удалён или создан без scope `yc.search-api.execute` → пересоздайте ключ.
+- **Cloud IAM**: SA-ключ битый или истёк → пересоздайте ключ.
 - **Legacy**: токен истёк (срок жизни 1 год) → получите новый через `get_token.sh`.
 
 ### `Wordstat 403 Forbidden`
-- Роль `search-api.webSearch.user` не назначена сервисному аккаунту, либо вы пытаетесь обратиться не к тому каталогу.
+- Роль `search-api.webSearch.user` не назначена субъекту ключа, scope API-ключа недостаточен, либо выбран не тот каталог.
 - Проверьте `yandex_cloud_folder_id` в `config.json`.
 
 ### `LibreSSL detected` (macOS)
@@ -173,7 +181,8 @@ brew install openssl@3
 
 ### `config/config.json present but invalid`
 - `yandex_cloud_folder_id` пустой → заполните
-- Файл ключа не найден по пути из `auth.service_account_key_file` → проверьте, что файл есть и читается. Помните: относительные пути резолвятся от корня скилла, а не от `config/`.
+- `auth.mode=api_key`, но `YANDEX_AI_API_KEY` отсутствует в `config/.env`
+- `auth.mode=iam`, но файл ключа не найден по пути из `auth.service_account_key_file`
 
 ### Хочу переключиться на другой бэкенд
 В `config/.env` добавьте:

--- a/plugins/yandex-wordstat/skills/yandex-wordstat/config/config.example.json
+++ b/plugins/yandex-wordstat/skills/yandex-wordstat/config/config.example.json
@@ -1,7 +1,6 @@
 {
   "yandex_cloud_folder_id": "b1g...",
   "auth": {
-    "service_account_key_file": "config/service_account_key.json",
-    "openssl_bin": "openssl"
+    "mode": "api_key"
   }
 }

--- a/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/common.sh
+++ b/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/common.sh
@@ -11,8 +11,8 @@
 # Backend dispatch:
 #   - WORDSTAT_BACKEND=legacy → POST api.wordstat.yandex.net/v1/{method} (Bearer OAuth)
 #   - WORDSTAT_BACKEND=cloud  → POST searchapi.api.cloud.yandex.net/v2/wordstat/{method}
-#                              with IAM Bearer + folderId, response normalized back to legacy
-#                              shape so existing parsers in callers don't change.
+#                              with AI Studio Api-Key or IAM Bearer + folderId;
+#                              response normalized back to legacy shape so callers don't change.
 #
 # Selection in load_config is STRUCTURAL ONLY — no network, no IAM preflight.
 # IAM/network errors surface on the first wordstat_request call.
@@ -39,6 +39,8 @@ WORDSTAT_README_URL="https://github.com/artwist-polyakov/polyakov-claude-skills/
 WORDSTAT_BACKEND=""
 WORDSTAT_BACKEND_DETECTED_VIA=""
 WORDSTAT_CLOUD_FOLDER_ID=""
+WORDSTAT_CLOUD_AUTH_MODE=""
+WORDSTAT_CLOUD_API_KEY=""
 WORDSTAT_CLOUD_SA_KEY_PATH=""
 WORDSTAT_CLOUD_OPENSSL_BIN=""
 
@@ -64,13 +66,9 @@ die_with_help() {
         printf '  %s\n\n' "$WORDSTAT_README_URL"
         printf 'Quick checks:\n'
         printf '  - cloud mode:  config/config.json has yandex_cloud_folder_id?\n'
-        if [ -n "$WORDSTAT_CLOUD_SA_KEY_PATH" ]; then
-            printf '                 SA key file: %s\n' "$WORDSTAT_CLOUD_SA_KEY_PATH"
-            printf '                 (resolved from auth.service_account_key_file) — present and readable?\n'
-        else
-            printf '                 SA key file from auth.service_account_key_file — present and readable?\n'
-        fi
-        printf "                 SA has role 'search-api.webSearch.user'?\n"
+        printf '                 API key: YANDEX_AI_API_KEY is set and valid?\n'
+        printf '                 IAM: auth.service_account_key_file is present and readable?\n'
+        printf "                 account has role 'search-api.webSearch.user'?\n"
         printf '  - legacy mode: YANDEX_WORDSTAT_TOKEN still valid? (tokens expire after 1 year)\n'
         printf '  - to switch:   set YANDEX_WORDSTAT_BACKEND=legacy|cloud in config/.env\n'
     } >&2
@@ -155,6 +153,7 @@ _detect_cloud_config() {
     [ -f "$_cfg_file" ] || return 1
 
     _folder=$(_cfg_get yandex_cloud_folder_id)
+    _auth_mode=$(_cfg_get auth.mode)
     _sa_rel=$(_cfg_get auth.service_account_key_file)
     _ossl=$(_cfg_get auth.openssl_bin)
 
@@ -162,22 +161,47 @@ _detect_cloud_config() {
         WORDSTAT_BACKEND_DETECTED_VIA="cloud (config.json present but yandex_cloud_folder_id missing)"
         return 2
     fi
-    if [ -z "$_sa_rel" ]; then
-        WORDSTAT_BACKEND_DETECTED_VIA="cloud (config.json present but auth.service_account_key_file missing)"
-        return 2
-    fi
-
-    _sa_resolved=$(_resolve_path "$_sa_rel")
-    if [ ! -r "$_sa_resolved" ]; then
-        WORDSTAT_CLOUD_SA_KEY_PATH="$_sa_resolved"
-        WORDSTAT_BACKEND_DETECTED_VIA="cloud (SA key file not found at resolved path)"
-        return 2
-    fi
-
     WORDSTAT_CLOUD_FOLDER_ID="$_folder"
-    WORDSTAT_CLOUD_SA_KEY_PATH="$_sa_resolved"
-    WORDSTAT_CLOUD_OPENSSL_BIN="${_ossl:-openssl}"
-    return 0
+
+    if [ -z "$_auth_mode" ]; then
+        if [ -n "${YANDEX_AI_API_KEY:-}" ] && [ -z "$_sa_rel" ]; then
+            _auth_mode="api_key"
+        else
+            _auth_mode="iam"
+        fi
+    fi
+
+    case "$_auth_mode" in
+        api_key)
+            if [ -z "${YANDEX_AI_API_KEY:-}" ]; then
+                WORDSTAT_BACKEND_DETECTED_VIA="cloud (auth.mode=api_key but YANDEX_AI_API_KEY missing)"
+                return 2
+            fi
+            WORDSTAT_CLOUD_AUTH_MODE="api_key"
+            WORDSTAT_CLOUD_API_KEY="$YANDEX_AI_API_KEY"
+            return 0
+            ;;
+        iam)
+            if [ -z "$_sa_rel" ]; then
+                WORDSTAT_BACKEND_DETECTED_VIA="cloud (auth.mode=iam but auth.service_account_key_file missing)"
+                return 2
+            fi
+            _sa_resolved=$(_resolve_path "$_sa_rel")
+            if [ ! -r "$_sa_resolved" ]; then
+                WORDSTAT_CLOUD_SA_KEY_PATH="$_sa_resolved"
+                WORDSTAT_BACKEND_DETECTED_VIA="cloud (SA key file not found at resolved path)"
+                return 2
+            fi
+            WORDSTAT_CLOUD_AUTH_MODE="iam"
+            WORDSTAT_CLOUD_SA_KEY_PATH="$_sa_resolved"
+            WORDSTAT_CLOUD_OPENSSL_BIN="${_ossl:-openssl}"
+            return 0
+            ;;
+        *)
+            WORDSTAT_BACKEND_DETECTED_VIA="cloud (invalid auth.mode=$_auth_mode)"
+            return 2
+            ;;
+    esac
 }
 
 load_config() {
@@ -265,7 +289,10 @@ print_backend_info() {
         cloud)
             echo "Backend: cloud ($WORDSTAT_BACKEND_DETECTED_VIA)"
             echo "  folder_id: $WORDSTAT_CLOUD_FOLDER_ID"
-            echo "  SA key:    $WORDSTAT_CLOUD_SA_KEY_PATH"
+            echo "  auth:      $WORDSTAT_CLOUD_AUTH_MODE"
+            if [ "$WORDSTAT_CLOUD_AUTH_MODE" = "iam" ]; then
+                echo "  SA key:    $WORDSTAT_CLOUD_SA_KEY_PATH"
+            fi
             echo ""
             echo "=== Endpoints ==="
             echo "  POST $WORDSTAT_CLOUD_API/topRequests"
@@ -690,7 +717,7 @@ _legacy_request() {
         -d "$_params"
 }
 
-# Cloud backend: translate, sign, POST, normalize
+# Cloud backend: translate, authorize, POST, normalize
 _cloud_request() {
     _method="$1"
     _params="$2"
@@ -716,11 +743,22 @@ _cloud_request() {
     fi
     _cloud_body="$_xlate_out"
 
-    # 2. Get IAM token (uses cache, falls back to issue)
-    _tok=$(_iam_token_get)
-    if [ -z "$_tok" ]; then
-        die_with_help "Failed to obtain IAM token"
-    fi
+    # 2. Select the configured authorization header.
+    case "$WORDSTAT_CLOUD_AUTH_MODE" in
+        api_key)
+            _auth_header="Authorization: Api-Key $WORDSTAT_CLOUD_API_KEY"
+            ;;
+        iam)
+            _tok=$(_iam_token_get)
+            if [ -z "$_tok" ]; then
+                die_with_help "Failed to obtain IAM token"
+            fi
+            _auth_header="Authorization: Bearer $_tok"
+            ;;
+        *)
+            die_with_help "Unknown cloud auth mode: $WORDSTAT_CLOUD_AUTH_MODE"
+            ;;
+    esac
 
     # 3. POST with retry on 5xx and refresh on 401
     _attempt=0
@@ -732,7 +770,7 @@ _cloud_request() {
         _resp_file="$_tmp/resp"
         _status=$(curl -s -o "$_resp_file" -w '%{http_code}' \
             -X POST "$WORDSTAT_CLOUD_API/$_method" \
-            -H "Authorization: Bearer $_tok" \
+            -H "$_auth_header" \
             -H "Content-Type: application/json" \
             -d "$_cloud_body")
 
@@ -743,22 +781,26 @@ _cloud_request() {
                 return 0
                 ;;
             401)
-                # Refresh once and retry
-                if [ "$_attempt" = "1" ]; then
+                # IAM tokens can be refreshed once. Static API keys cannot.
+                if [ "$WORDSTAT_CLOUD_AUTH_MODE" = "iam" ] && [ "$_attempt" = "1" ]; then
                     rm -f "$WORDSTAT_CACHE_DIR/iam_token.json"
                     _tok=$(_iam_token_issue)
+                    _auth_header="Authorization: Bearer $_tok"
                     rm -rf "$_tmp"
                     continue
                 fi
                 _err=$(cat "$_resp_file" 2>/dev/null)
                 rm -rf "$_tmp"
+                if [ "$WORDSTAT_CLOUD_AUTH_MODE" = "api_key" ]; then
+                    die_with_help "Cloud Wordstat 401 Unauthorized: AI Studio API key was rejected" "$_err"
+                fi
                 die_with_help "Cloud Wordstat 401 Unauthorized after token refresh" "$_err"
                 ;;
             403)
                 _err=$(cat "$_resp_file" 2>/dev/null)
                 rm -rf "$_tmp"
                 die_with_help "Cloud Wordstat 403 Forbidden" \
-                    "Check that your service account has the role 'search-api.webSearch.user' on folder $WORDSTAT_CLOUD_FOLDER_ID. Raw: $_err"
+                    "Check role 'search-api.webSearch.user', API-key scope 'yc.search-api.execute', and folder $WORDSTAT_CLOUD_FOLDER_ID. Raw: $_err"
                 ;;
             5[0-9][0-9]|000)
                 if [ "$_attempt" -lt "$_max_attempts" ]; then

--- a/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/tests/test_api_key_auth.sh
+++ b/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/tests/test_api_key_auth.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Verify AI Studio API-key selection and request authorization without network.
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+td="${TMPDIR:-/tmp}/wordstat_api_key_test_$$"
+rm -rf "$td"
+mkdir -p "$td/config" "$td/cache" "$td/bin"
+trap 'rm -rf "$td"' EXIT INT TERM
+
+cat > "$td/config/config.json" <<'EOF'
+{"yandex_cloud_folder_id":"b1g-api-key-test","auth":{"mode":"api_key"}}
+EOF
+
+cat > "$td/bin/curl" <<'EOF'
+#!/bin/sh
+capture="${FAKE_CAPTURE:?}"
+response="${FAKE_RESPONSE:?}"
+out=""
+
+printf '%s\n' "$@" > "$capture"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            out="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+cp "$response" "$out"
+printf '200'
+EOF
+chmod +x "$td/bin/curl"
+
+WORDSTAT_SCRIPT_DIR="$SCRIPTS_DIR"
+WORDSTAT_SKILL_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+WORDSTAT_CONFIG_DIR="$td/config"
+WORDSTAT_CACHE_DIR="$td/cache"
+YANDEX_AI_API_KEY="test-api-secret"
+FAKE_CAPTURE="$td/curl-args"
+FAKE_RESPONSE="$TESTS_DIR/fixtures/cloud-topRequests-response.json"
+PATH="$td/bin:$PATH"
+export WORDSTAT_SCRIPT_DIR WORDSTAT_SKILL_DIR WORDSTAT_CONFIG_DIR
+export WORDSTAT_CACHE_DIR YANDEX_AI_API_KEY FAKE_CAPTURE FAKE_RESPONSE PATH
+
+# shellcheck disable=SC1091
+. "$SCRIPTS_DIR/common.sh"
+
+load_config
+
+[ "$WORDSTAT_BACKEND" = "cloud" ] || {
+    echo "FAIL: expected cloud backend, got '$WORDSTAT_BACKEND'"
+    exit 1
+}
+[ "$WORDSTAT_CLOUD_AUTH_MODE" = "api_key" ] || {
+    echo "FAIL: expected api_key auth mode, got '$WORDSTAT_CLOUD_AUTH_MODE'"
+    exit 1
+}
+
+actual=$(wordstat_request "topRequests" '{"phrase":"юрист дтп"}')
+expected=$(cat "$TESTS_DIR/fixtures/legacy-topRequests-expected.json")
+
+ACTUAL="$actual" EXPECTED="$expected" python3 - <<'PY'
+import json
+import os
+
+assert json.loads(os.environ["ACTUAL"]) == json.loads(os.environ["EXPECTED"])
+PY
+
+grep -Fxq 'Authorization: Api-Key test-api-secret' "$FAKE_CAPTURE" || {
+    echo "FAIL: Api-Key authorization header was not sent"
+    exit 1
+}
+if grep -Fq 'Authorization: Bearer' "$FAKE_CAPTURE"; then
+    echo "FAIL: IAM Bearer header leaked into API-key mode"
+    exit 1
+fi
+
+echo "test_api_key_auth: all passed"


### PR DESCRIPTION
Добавляет необязательную авторизацию Wordstat через API-ключ сервисного аккаунта (`auth.mode=api_key`, `YANDEX_AI_API_KEY`). Существующие конфигурации с авторизованным JSON-ключом продолжают использовать IAM, в том числе при установленной переменной API-ключа.

Ветка совмещена с актуальным main: используется только Cloud API, удалённый legacy OAuth не возвращается. IAM остаётся в примере конфигурации.

Исправлены замечания ревью: описаны обязательный сервисный аккаунт, роль, явный scope `yc.search-api.execute` и путь создания ключа; добавлен `.env.example`; объяснён выбор режима без `auth.mode`; сохранён разрешённый путь к JSON-ключу в диагностике IAM.

Проверка: `sh plugins/yandex-wordstat/skills/yandex-wordstat/scripts/tests/run.sh` — 8 passed, 0 failed. Проверены API-key заголовок и нормализация ответа; актуальные тесты main также проходят. 



Дополнительная проверка после ревью 18 сентября:
- API-key тест читает ключ из временного config/.env; старый конфиг без auth.mode с дополнительным ключом в .env сохраняет IAM и заголовок Bearer.
- test_selector изолирован от экспортированного YANDEX_AI_API_KEY; воспроизведённое падение исправлено.
- Убрано дублирование инструкции, оба способа входа названы в начале, подсказки 401 разделены по режимам.
- Все 8 тестов проходят, отдельно проходит test_selector с экспортированным фиктивным ключом.
- Получен HTTP 200 с настоящим API-ключом через конфигурацию и auth selection этой ветки; штатный quota.sh этой ветки также завершился Wordstat API: OK. Секреты и пользовательская конфигурация не публикуются.
