### PR TITLE
Add Yandex Search API key authentication

### DIFF
--- a/plugins/yandex-search-api/skills/yandex-search-api/.gitignore
+++ b/plugins/yandex-search-api/skills/yandex-search-api/.gitignore
@@ -1,5 +1,6 @@
 # Config with secrets
 config/config.json
+config/.env
 config/service_account_key.json
 
 # Cache files (generated at runtime)

--- a/plugins/yandex-search-api/skills/yandex-search-api/SKILL.md
+++ b/plugins/yandex-search-api/skills/yandex-search-api/SKILL.md
@@ -13,15 +13,16 @@ Parse Yandex SERP via Yandex Cloud Search API v2 (sync + async).
 
 ## Config
 
-Для работы нужен сервисный аккаунт Яндекс.Облака.
+Рекомендуемый способ авторизации — API-ключ Yandex AI Studio. IAM через
+сервисный аккаунт также поддерживается.
 Пошаговая инструкция (6 шагов, ~10 минут): [config/README.md](config/README.md).
 
 Краткий чеклист:
 1. ID каталога Яндекс.Облака → в `config.json`
-2. Файл ключа сервисного аккаунта → в `config/service_account_key.json`
-3. Проверка: `bash scripts/iam_token_get.sh`
+2. `auth.mode: "api_key"` → в `config.json`
+3. `YANDEX_AI_API_KEY` → в `config/.env`
 
-> macOS: может потребоваться `brew install openssl` — подробности в config/README.md.
+> IAM fallback: сервисный аккаунт и OpenSSL — подробности в config/README.md.
 
 ## Workflow
 
@@ -46,14 +47,16 @@ Parse Yandex SERP via Yandex Cloud Search API v2 (sync + async).
 2. **Режим поиска** берётся из `config.json` → `search.mode` (по умолчанию `sync`).
    Не спрашивай — используй то, что в конфиге.
 
-3. **Verify config**: `bash scripts/iam_token_get.sh`
+3. **Verify config**: убедись, что заданы `yandex_cloud_folder_id`,
+   `auth.mode` и соответствующий credential. Не печатай ключ или токен.
 4. **Run search** с полученным region ID
 5. **Present results** with position, title, URL, snippet
 
 ## Scripts
 
 ### iam_token_get.sh
-Generate or validate IAM token from Service Account key.
+Generate or validate IAM token from Service Account key. Needed only when
+`auth.mode` is `iam`.
 ```bash
 bash scripts/iam_token_get.sh
 ```
@@ -160,11 +163,8 @@ Run `bash scripts/regions_tree.sh` for full list.
 
 ## Pricing
 
-Yandex Search API v2 pricing (as of 2025):
-- Sync requests: billed per request
-- Async requests: billed per request
-- Free tier available (check current limits)
-- See: https://yandex.cloud/ru/docs/search-api/pricing
+Search requests may be billable. Check current terms before running a large
+batch: https://yandex.cloud/ru/docs/search-api/pricing
 
 ## Example Session
 
@@ -179,8 +179,7 @@ Claude: [Находит ID региона]
         bash scripts/search_region.sh --name "Москва"
         → Москва = 213
 
-        [Проверяет токен]
-        bash scripts/iam_token_get.sh
+        [Проверяет конфигурацию авторизации без вывода секрета]
 
         [Выполняет поиск — 1 запрос, автоматически sync]
         bash scripts/web_search_sync.sh --query "купить сэндвич дымоход" --region-id 213
@@ -203,8 +202,7 @@ Claude: [Находит ID региона]
         bash scripts/search_region.sh --name "Казань"
         → Казань = 43
 
-        [Проверяет токен]
-        bash scripts/iam_token_get.sh
+        [Проверяет конфигурацию авторизации без вывода секрета]
 
         [Режим sync из конфига — запускает батч по одному]
         bash scripts/web_search_sync.sh --file queries.txt --region-id 43

--- a/plugins/yandex-search-api/skills/yandex-search-api/config/README.md
+++ b/plugins/yandex-search-api/skills/yandex-search-api/config/README.md
@@ -1,145 +1,117 @@
 # Настройка Yandex Search API
 
-Для работы скилла нужен сервисный аккаунт в Яндекс.Облаке.
+Для работы нужны каталог Yandex Cloud, роль Search API и один из способов
+авторизации:
 
-## Шаг 1: Создайте каталог в Яндекс.Облаке
+- API-ключ Yandex AI Studio — рекомендуемый вариант;
+- IAM через ключ сервисного аккаунта — совместимый fallback.
 
-1. Откройте https://console.yandex.cloud/
-2. Если нет аккаунта — зарегистрируйтесь (нужен Яндекс ID)
-3. Создайте **каталог** (folder) или используйте существующий
-4. Скопируйте **ID каталога** — он понадобится дальше
+## Вариант A: API-ключ Yandex AI Studio
 
-> ID каталога выглядит так: `b1gabcdef12345678900`
-> Найти его можно: Консоль → ваш каталог → кнопка "ID" справа от названия
+### Шаг 1: подготовьте каталог
 
-## Шаг 2: Создайте сервисный аккаунт
+1. Откройте https://console.yandex.cloud/ и выберите каталог.
+2. Скопируйте его ID. Он выглядит как `b1gabcdef12345678900`.
+3. Убедитесь, что в каталоге активирован Search API.
+4. Назначьте субъекту ключа роль `search-api.webSearch.user`.
 
-1. В консоли откройте ваш каталог
-2. Слева выберите **Сервисные аккаунты** (раздел IAM)
-3. Нажмите **Создать сервисный аккаунт**
-4. Имя: `search-api-sa` (или любое другое)
-5. Нажмите **Создать**
+API-ключ должен иметь scope `yc.search-api.execute`. Создать и настроить ключ
+можно в Yandex AI Studio: https://aistudio.yandex.ru/
 
-## Шаг 3: Назначьте роль
-
-Сервисному аккаунту нужна роль для доступа к Search API:
-
-1. Откройте созданный сервисный аккаунт
-2. Перейдите в раздел **Роли** (или назначьте через настройки каталога)
-3. Нажмите **Назначить роль**
-4. Найдите и выберите: `search-api.webSearch.user`
-5. Сохраните
-
-## Шаг 4: Создайте ключ авторизации
-
-1. Откройте сервисный аккаунт
-2. Перейдите на вкладку **Авторизованные ключи**
-3. Нажмите **Создать авторизованный ключ**
-4. Скачайте JSON-файл ключа
-5. Переименуйте его в `service_account_key.json`
-6. Положите в папку `config/` (рядом с этим README)
-
-> Этот файл секретный! Не добавляйте его в git (он уже в .gitignore).
-
-## Шаг 5: Создайте config.json
-
-Скопируйте пример:
+### Шаг 2: создайте config.json
 
 ```bash
 cp config/config.example.json config/config.json
 ```
 
-Откройте `config.json` и замените `"b1g..."` на ваш ID каталога из Шага 1:
+Замените placeholder на ID каталога:
 
 ```json
 {
   "yandex_cloud_folder_id": "b1gabcdef12345678900",
   "auth": {
-    "service_account_key_file": "config/service_account_key.json"
+    "mode": "api_key"
   }
 }
 ```
 
-Остальные поля можно не менять — значения по умолчанию подходят для большинства случаев.
+Остальные секции из примера оставьте без изменений.
 
-## Шаг 6: Проверьте
+### Шаг 3: сохраните ключ локально
+
+Создайте `config/.env`:
+
+```bash
+YANDEX_AI_API_KEY=AQVN_your_api_key
+```
+
+```bash
+chmod 600 config/.env
+```
+
+`config/.env` и `config/config.json` исключены из git. Никогда не печатайте
+ключ в логах, отчётах или сообщениях.
+
+## Вариант B: IAM через сервисный аккаунт
+
+1. Создайте сервисный аккаунт в каталоге Yandex Cloud.
+2. Назначьте ему роль `search-api.webSearch.user`.
+3. Создайте авторизованный ключ и сохраните JSON как
+   `config/service_account_key.json`.
+4. Укажите IAM-режим:
+
+```json
+{
+  "yandex_cloud_folder_id": "b1gabcdef12345678900",
+  "auth": {
+    "mode": "iam",
+    "service_account_key_file": "config/service_account_key.json",
+    "openssl_bin": "openssl"
+  }
+}
+```
+
+5. Проверьте генерацию токена:
 
 ```bash
 bash scripts/iam_token_get.sh
 ```
 
-Если всё правильно — увидите "IAM token cached" и можно искать.
-
-## Для пользователей macOS
-
-На macOS вместо OpenSSL стоит LibreSSL, который не поддерживает нужный алгоритм подписи. Если при проверке видите ошибку про LibreSSL:
-
-1. Установите OpenSSL:
-   ```bash
-   brew install openssl
-   ```
-
-2. Добавьте путь к OpenSSL в `config.json`:
-   ```json
-   {
-     "yandex_cloud_folder_id": "b1g...",
-     "auth": {
-       "service_account_key_file": "config/service_account_key.json",
-       "openssl_bin": "/opt/homebrew/bin/openssl"
-     }
-   }
-   ```
-
-> `/opt/homebrew/bin/openssl` — для Mac на Apple Silicon (M1/M2/M3/M4).
-> Для Intel Mac путь: `/usr/local/opt/openssl/bin/openssl`.
-> Узнать точный путь: `brew --prefix openssl`
+На macOS может понадобиться `brew install openssl` и путь
+`/opt/homebrew/bin/openssl` (Apple Silicon) либо
+`/usr/local/opt/openssl/bin/openssl` (Intel).
 
 ## Частые проблемы
 
-### "Error: LibreSSL detected"
-macOS по умолчанию использует LibreSSL вместо OpenSSL. См. раздел выше "Для пользователей macOS".
+### `auth.mode=api_key requires YANDEX_AI_API_KEY`
 
-### "Error: 403 Forbidden"
-- Не назначена роль `search-api.webSearch.user` → назначьте (Шаг 3)
-- Неправильный ID каталога → проверьте `yandex_cloud_folder_id`
+Нет `config/.env`, переменная названа неверно или файл недоступен.
 
-### "Error: config.json not found"
-Не создан файл конфигурации → выполните Шаг 5.
+### `403 Forbidden`
 
-### "Error: openssl not found"
-OpenSSL не установлен или не в PATH → установите через `brew install openssl` и укажите путь в конфиге.
+Проверьте роль `search-api.webSearch.user`, scope ключа
+`yc.search-api.execute`, ID каталога и принадлежность ключа каталогу.
+
+### `config.json not found`
+
+Скопируйте `config/config.example.json` в `config/config.json`.
+
+### Ошибка LibreSSL или OpenSSL
+
+Она относится только к IAM-режиму. Установите OpenSSL и укажите
+`auth.openssl_bin` в `config.json`.
 
 ## Лимиты и цены
 
-- Бесплатный тариф: есть (проверяйте актуальные лимиты)
-- Подробнее: https://yandex.cloud/ru/docs/search-api/pricing
+Запросы Search API могут тарифицироваться. Перед массовым запуском проверьте
+актуальные условия: https://yandex.cloud/ru/docs/search-api/pricing
 
 ## Настройки по умолчанию
 
-Эти настройки можно менять в `config.json`, но для начала подойдут как есть:
-
 | Настройка | Значение | Что это |
 |-----------|----------|---------|
-| Регион | Россия (225) | Откуда "смотрим" поиск |
+| Регион | Россия (225) | Откуда «смотрим» поиск |
 | Тип поиска | Русскоязычный | Поиск по рунету |
 | Фильтр контента | Умеренный | Фильтрует откровенный контент |
-| Исправление опечаток | Включено | Яндекс сам исправляет опечатки |
+| Исправление опечаток | Включено | Яндекс исправляет опечатки |
 | Результатов на странице | 10 | Сколько ссылок в ответе |
-
-## Альтернатива: настройка через CLI
-
-Если у вас установлен `yc` (Yandex Cloud CLI), можно сделать всё через командную строку:
-
-```bash
-# Создать сервисный аккаунт
-yc iam service-account create --name search-api-sa
-
-# Назначить роль (замените <FOLDER_ID> и <SA_ID>)
-yc resource-manager folder add-access-binding <FOLDER_ID> \
-  --role search-api.webSearch.user \
-  --subject serviceAccount:<SA_ID>
-
-# Создать ключ
-yc iam key create --service-account-name search-api-sa \
-  --output config/service_account_key.json
-```

--- a/plugins/yandex-search-api/skills/yandex-search-api/config/config.example.json
+++ b/plugins/yandex-search-api/skills/yandex-search-api/config/config.example.json
@@ -1,8 +1,7 @@
 {
   "yandex_cloud_folder_id": "b1g...",
   "auth": {
-    "service_account_key_file": "config/service_account_key.json",
-    "openssl_bin": "openssl"
+    "mode": "api_key"
   },
   "search": {
     "mode": "sync",

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/common.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/common.sh
@@ -60,6 +60,12 @@ check_prerequisites() {
 # --- Config loading (JSON via python3) ---
 
 load_config() {
+    _env_file="$SKILL_DIR/config/.env"
+    if [ -f "$_env_file" ]; then
+        # shellcheck disable=SC1090
+        . "$_env_file"
+    fi
+
     if [ ! -f "$CONFIG_FILE" ]; then
         echo "Error: config.json not found at $CONFIG_FILE" >&2
         echo "Copy config.example.json to config.json and fill in your values." >&2
@@ -94,6 +100,60 @@ else:
     print(v)
 " 2>/dev/null)
     echo "$_val"
+}
+
+# Select API-key or IAM authorization. A missing mode preserves the original
+# service-account configuration, while allowing key-only installs to opt in
+# without an extra config field.
+cloud_auth_mode() {
+    _cam_mode=$(cfg_get "auth.mode")
+    _cam_sa_path=$(cfg_get "auth.service_account_key_file")
+
+    if [ -z "$_cam_mode" ]; then
+        if [ -n "${YANDEX_AI_API_KEY:-}" ] && [ -z "$_cam_sa_path" ]; then
+            _cam_mode="api_key"
+        else
+            _cam_mode="iam"
+        fi
+    fi
+
+    case "$_cam_mode" in
+        api_key|iam)
+            printf '%s\n' "$_cam_mode"
+            ;;
+        *)
+            echo "Error: auth.mode must be api_key or iam" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Print one complete Authorization header. Callers must pass it directly to
+# curl and must never log the result.
+cloud_auth_header() {
+    _cah_mode=$(cloud_auth_mode) || return 1
+
+    case "$_cah_mode" in
+        api_key)
+            if [ -z "${YANDEX_AI_API_KEY:-}" ]; then
+                echo "Error: auth.mode=api_key requires YANDEX_AI_API_KEY" >&2
+                return 1
+            fi
+            printf 'Authorization: Api-Key %s\n' "$YANDEX_AI_API_KEY"
+            ;;
+        iam)
+            _cah_token=$(get_cached_iam_token)
+            if [ -z "$_cah_token" ]; then
+                sh "$SCRIPT_DIR/iam_token_get.sh" >&2 || return 1
+                _cah_token=$(get_cached_iam_token)
+            fi
+            if [ -z "$_cah_token" ]; then
+                echo "Error: IAM token generation produced no token" >&2
+                return 1
+            fi
+            printf 'Authorization: Bearer %s\n' "$_cah_token"
+            ;;
+    esac
 }
 
 # --- Temp file management ---
@@ -233,7 +293,8 @@ http_request() {
                 ;;
             403)
                 echo "Error: 403 Forbidden. Check:" >&2
-                echo "  - Role 'search-api.webSearch.user' assigned to SA" >&2
+                echo "  - Role 'search-api.webSearch.user' assigned to the key subject" >&2
+                echo "  - API-key scope 'yc.search-api.execute'" >&2
                 echo "  - Correct folder_id in config.json" >&2
                 cat "$_resp_file" >&2
                 rm -rf "$_tmpdir_http" "$_hr_tmpdir"
@@ -262,18 +323,15 @@ http_request() {
     return 1
 }
 
-# Authenticated request (adds IAM token and folder-id headers)
+# Authenticated request (adds API-key or IAM authorization and folder header)
 # Usage: auth_request "POST" "url" "body"
 auth_request() {
     _ar_method="$1"
     _ar_url="$2"
     _ar_body="$3"
 
-    _iam_token=$(get_cached_iam_token)
-    if [ -z "$_iam_token" ]; then
-        echo "Error: No valid IAM token. Run iam_token_get.sh first." >&2
-        return 1
-    fi
+    _auth_mode=$(cloud_auth_mode) || return 1
+    _auth_header=$(cloud_auth_header) || return 1
 
     _folder_id=$(cfg_get "yandex_cloud_folder_id")
     if [ -z "$_folder_id" ]; then
@@ -282,22 +340,22 @@ auth_request() {
     fi
 
     _result=$(http_request "$_ar_method" "$_ar_url" "$_ar_body" \
-        "Authorization: Bearer $_iam_token" \
+        "$_auth_header" \
         "x-folder-id: $_folder_id" \
         "Content-Type: application/json") || {
-        # On 401, auto-refresh token and retry once
-        if echo "$_result" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('code')==16 else 1)" 2>/dev/null; then
+        # Only IAM credentials can be refreshed. Static API keys fail closed.
+        if [ "$_auth_mode" = "iam" ] && echo "$_result" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('code')==16 else 1)" 2>/dev/null; then
             echo "Token expired, auto-refreshing..." >&2
             rm -f "$CACHE_DIR/iam_token.json"
             sh "$SCRIPT_DIR/iam_token_get.sh" >&2 || { echo "Error: Token refresh failed" >&2; return 1; }
-            _iam_token=$(get_cached_iam_token)
-            if [ -z "$_iam_token" ]; then
+            _auth_header=$(cloud_auth_header) || return 1
+            if [ -z "$_auth_header" ]; then
                 echo "Error: Token refresh produced no token" >&2
                 return 1
             fi
             # Retry with new token
             _result=$(http_request "$_ar_method" "$_ar_url" "$_ar_body" \
-                "Authorization: Bearer $_iam_token" \
+                "$_auth_header" \
                 "x-folder-id: $_folder_id" \
                 "Content-Type: application/json") || return 1
         else

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/run.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/run.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Offline test runner for yandex-search-api.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+passed=0
+failed=0
+
+for test_file in "$TESTS_DIR"/test_*.sh; do
+    [ -f "$test_file" ] || continue
+    test_name=$(basename "$test_file" .sh)
+    printf '%s ... ' "$test_name"
+    if sh "$test_file" >/dev/null 2>&1; then
+        echo PASS
+        passed=$((passed + 1))
+    else
+        echo FAIL
+        failed=$((failed + 1))
+        echo "--- $test_name output ---"
+        sh "$test_file" 2>&1 || true
+        echo "--- end output ---"
+    fi
+done
+
+echo ""
+echo "Results: $passed passed, $failed failed"
+[ "$failed" -eq 0 ]

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/test_api_key_auth.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/test_api_key_auth.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# Verify API-key auth at the real auth_request boundary without network access.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+td="${TMPDIR:-/tmp}/ysa_api_key_test_$$"
+trap 'rm -rf "$td"' EXIT INT TERM
+
+mkdir -p "$td/skill/scripts" "$td/skill/config" "$td/skill/cache" "$td/bin"
+cp "$SOURCE_SCRIPTS_DIR/common.sh" "$td/skill/scripts/common.sh"
+
+cat > "$td/skill/config/config.json" <<'EOF'
+{
+  "yandex_cloud_folder_id": "b1g-test-folder",
+  "auth": {"mode": "api_key"}
+}
+EOF
+
+cat > "$td/skill/config/.env" <<'EOF'
+YANDEX_AI_API_KEY=test-api-secret
+EOF
+
+cat > "$td/skill/scripts/iam_token_get.sh" <<'EOF'
+#!/bin/sh
+echo called > "${IAM_MARKER:?}"
+exit 97
+EOF
+chmod +x "$td/skill/scripts/iam_token_get.sh"
+
+cat > "$td/bin/curl" <<'EOF'
+#!/bin/sh
+response_file=""
+headers_file=""
+
+{
+    echo '--- request ---'
+    printf '%s\n' "$@"
+} >> "${CURL_CAPTURE:?}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            response_file="$2"
+            shift 2
+            ;;
+        -D)
+            headers_file="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+printf '{}' > "$response_file"
+: > "$headers_file"
+printf '200'
+EOF
+chmod +x "$td/bin/curl"
+
+cat > "$td/skill/scripts/harness.sh" <<'EOF'
+#!/bin/sh
+set -eu
+. "$(dirname "$0")/common.sh"
+load_config
+auth_request POST 'https://searchapi.api.cloud.yandex.net/v2/web/search' '{}'
+EOF
+chmod +x "$td/skill/scripts/harness.sh"
+
+CURL_CAPTURE="$td/curl-args"
+IAM_MARKER="$td/iam-called"
+PATH="$td/bin:$PATH"
+export CURL_CAPTURE IAM_MARKER PATH
+
+sh "$td/skill/scripts/harness.sh" >/dev/null
+
+grep -Fxq 'Authorization: Api-Key test-api-secret' "$CURL_CAPTURE" || {
+    echo 'FAIL: API-key header was not sent'
+    exit 1
+}
+if grep -Fq 'Authorization: Bearer' "$CURL_CAPTURE"; then
+    echo 'FAIL: Bearer header leaked into API-key mode'
+    exit 1
+fi
+[ ! -e "$IAM_MARKER" ] || {
+    echo 'FAIL: API-key mode invoked IAM token generation'
+    exit 1
+}
+[ ! -e "$td/skill/cache/iam_token.json" ] || {
+    echo 'FAIL: API-key mode created an IAM token cache'
+    exit 1
+}
+
+rm "$td/skill/config/.env" "$CURL_CAPTURE"
+if sh "$td/skill/scripts/harness.sh" >"$td/missing-key.out" 2>&1; then
+    echo 'FAIL: explicit API-key mode succeeded without a key'
+    exit 1
+fi
+grep -Fq 'auth.mode=api_key requires YANDEX_AI_API_KEY' "$td/missing-key.out" || {
+    echo 'FAIL: missing API-key diagnostic is not actionable'
+    exit 1
+}
+[ ! -e "$CURL_CAPTURE" ] || {
+    echo 'FAIL: missing API key reached HTTP transport'
+    exit 1
+}
+[ ! -e "$IAM_MARKER" ] || {
+    echo 'FAIL: missing API key fell back to IAM'
+    exit 1
+}
+
+echo 'test_api_key_auth: all passed'

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/test_api_key_auth.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/test_api_key_auth.sh
@@ -112,4 +112,33 @@ grep -Fq 'auth.mode=api_key requires YANDEX_AI_API_KEY' "$td/missing-key.out" ||
     exit 1
 }
 
+cat > "$td/skill/config/config.json" <<'EOF'
+{
+  "yandex_cloud_folder_id": "b1g-test-folder",
+  "auth": {
+    "mode": "iam",
+    "service_account_key_file": "config/service-account.json"
+  }
+}
+EOF
+cat > "$td/skill/cache/iam_token.json" <<'EOF'
+{"iam_token":"test-iam-secret","expires_at":4102444800}
+EOF
+rm -f "$IAM_MARKER" "$CURL_CAPTURE"
+
+sh "$td/skill/scripts/harness.sh" >/dev/null
+
+grep -Fxq 'Authorization: Bearer test-iam-secret' "$CURL_CAPTURE" || {
+    echo 'FAIL: IAM mode no longer sends the cached Bearer token'
+    exit 1
+}
+if grep -Fq 'Authorization: Api-Key' "$CURL_CAPTURE"; then
+    echo 'FAIL: API-key header leaked into IAM mode'
+    exit 1
+fi
+[ ! -e "$IAM_MARKER" ] || {
+    echo 'FAIL: valid cached IAM token triggered regeneration'
+    exit 1
+}
+
 echo 'test_api_key_auth: all passed'

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/test_api_key_scripts.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/test_api_key_scripts.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# Exercise sync, async-submit, and async-poll through a fake HTTP transport.
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_SKILL_DIR="$(cd "$TESTS_DIR/../.." && pwd)"
+td="${TMPDIR:-/tmp}/ysa_api_key_scripts_test_$$"
+trap 'rm -rf "$td"' EXIT INT TERM
+
+mkdir -p "$td/skill" "$td/bin"
+cp -R "$SOURCE_SKILL_DIR/." "$td/skill/"
+mkdir -p "$td/skill/cache"
+
+cat > "$td/skill/config/config.json" <<'EOF'
+{
+  "yandex_cloud_folder_id": "b1g-test-folder",
+  "auth": {"mode": "api_key"},
+  "search": {"region_id": "225", "results_per_page": 1},
+  "async": {"poll_interval_minutes": 0, "max_wait_minutes": 1}
+}
+EOF
+cat > "$td/skill/config/.env" <<'EOF'
+YANDEX_AI_API_KEY=test-api-secret
+EOF
+
+cat > "$td/skill/scripts/iam_token_get.sh" <<'EOF'
+#!/bin/sh
+echo called > "${IAM_MARKER:?}"
+exit 97
+EOF
+chmod +x "$td/skill/scripts/iam_token_get.sh"
+
+FAKE_RAW_B64=$(python3 - <<'PY'
+import base64
+xml = b'''<yandexsearch><response><results><grouping><group><doc>
+<url>https://example.com/</url><title>Example result</title>
+<passages><passage>Example snippet</passage></passages>
+<domain>example.com</domain></doc></group></grouping></results></response></yandexsearch>'''
+print(base64.b64encode(xml).decode())
+PY
+)
+
+cat > "$td/bin/curl" <<'EOF'
+#!/bin/sh
+response_file=""
+headers_file=""
+url=""
+
+{
+    echo '--- request ---'
+    printf '%s\n' "$@"
+} >> "${CURL_CAPTURE:?}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            response_file="$2"
+            shift 2
+            ;;
+        -D)
+            headers_file="$2"
+            shift 2
+            ;;
+        http*)
+            url="$1"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+case "$url" in
+    */v2/web/searchAsync)
+        printf '{"id":"op-test"}' > "$response_file"
+        ;;
+    */operations/op-test)
+        printf '{"done":true,"response":{"rawData":"%s"}}' "$FAKE_RAW_B64" > "$response_file"
+        ;;
+    */v2/web/search)
+        printf '{"rawData":"%s"}' "$FAKE_RAW_B64" > "$response_file"
+        ;;
+    *)
+        printf '{"code":3,"message":"unexpected fake URL"}' > "$response_file"
+        : > "$headers_file"
+        printf '400'
+        exit 0
+        ;;
+esac
+
+: > "$headers_file"
+printf '200'
+EOF
+chmod +x "$td/bin/curl"
+
+CURL_CAPTURE="$td/curl-args"
+IAM_MARKER="$td/iam-called"
+PATH="$td/bin:$PATH"
+export CURL_CAPTURE IAM_MARKER FAKE_RAW_B64 PATH
+
+sh "$td/skill/scripts/web_search_sync.sh" \
+    --query 'example smoke query' --results 1 >/dev/null
+
+printf '%s\n' 'example smoke query' > "$td/queries.txt"
+sh "$td/skill/scripts/web_search_async.sh" \
+    --file "$td/queries.txt" --results 1 --poll-interval 0 --max-wait 1 >/dev/null
+
+[ ! -e "$IAM_MARKER" ] || {
+    echo 'FAIL: an API-key script invoked IAM token generation'
+    exit 1
+}
+if grep -Fq 'Authorization: Bearer' "$CURL_CAPTURE"; then
+    echo 'FAIL: a script sent Bearer authorization in API-key mode'
+    exit 1
+fi
+api_key_count=$(grep -Fc 'Authorization: Api-Key test-api-secret' "$CURL_CAPTURE")
+[ "$api_key_count" -eq 3 ] || {
+    echo "FAIL: expected 3 API-key requests, got $api_key_count"
+    exit 1
+}
+
+result_file=$(find "$td/skill/cache/results" -name '*.json' -type f | head -n 1)
+[ -n "$result_file" ] || {
+    echo 'FAIL: scripts produced no parsed result file'
+    exit 1
+}
+grep -Fq 'https://example.com/' "$result_file" || {
+    echo 'FAIL: parsed result does not contain the fake search document'
+    exit 1
+}
+
+echo 'test_api_key_scripts: all passed'

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/web_search_async.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/web_search_async.sh
@@ -251,13 +251,6 @@ elif [ -n "$QUERIES_FILE" ]; then
         exit 1
     fi
 
-    # Ensure IAM token
-    _token=$(get_cached_iam_token)
-    if [ -z "$_token" ]; then
-        echo "No valid IAM token. Generating..." >&2
-        sh "$SCRIPT_DIR/iam_token_get.sh"
-    fi
-
     echo "=== Async Search: Submitting queries ==="
     echo "NOTE: This may take minutes to hours. The script will poll every $POLL_INTERVAL minutes."
     echo "Max wait: $MAX_WAIT minutes. Use --resume to continue if interrupted."

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/web_search_sync.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/web_search_sync.sh
@@ -52,13 +52,6 @@ if [ -z "$QUERY" ] && [ -z "$QUERIES_FILE" ]; then
     exit 1
 fi
 
-# Ensure IAM token is available
-_token=$(get_cached_iam_token)
-if [ -z "$_token" ]; then
-    echo "No valid IAM token. Generating..." >&2
-    sh "$SCRIPT_DIR/iam_token_get.sh"
-fi
-
 # Create results directory
 mkdir -p "$CACHE_DIR/results"
 


### PR DESCRIPTION
Добавляет необязательную авторизацию Search API через API-ключ сервисного аккаунта для синхронного поиска, асинхронной отправки и опроса операций. Существующая IAM-конфигурация сохраняет поведение даже при установленном `YANDEX_AI_API_KEY`; IAM остаётся в примере конфигурации.

Ветка совмещена с актуальным main. Исправлены замечания ревью:
- При отклонении ключа сообщение API выводится в stderr; попыток обновления IAM нет.
- Тест копирует только необходимые скрипты, не переносит пользовательские секреты и кеш. Проверяется первый запуск без каталога cache.
- Добавлен `.env.example`, описаны сервисный аккаунт, роль, явный scope `yc.search-api.execute`, путь создания ключа и выбор режима без `auth.mode`.
- Убраны обязательная предварительная генерация IAM и устаревшее указание числа шагов. Отложенное получение IAM также устраняет прежний сбой первого запуска до создания cache/results.

Проверки: `sh plugins/yandex-search-api/skills/yandex-search-api/scripts/tests/run.sh` — 8 passed, 0 skipped, 0 failed; `sh -n` для всех shell-скриптов. Регрессия потери текста 401 воспроизведена до исправления. Дополнительно тест выполнен с pending-операцией и синтетическим секретом в исходном каталоге. 



Финальная проверка 19 сентября:
- В начале README явно названы оба способа входа; шаги IAM обозначены отдельно, добавлены подсказки 401 для каждого режима.
- Воспроизведено и исправлено влияние экспортированного YANDEX_AI_API_KEY на проверку отсутствующего ключа.
- Полный набор проходит как в обычном окружении, так и с YANDEX_AI_API_KEY=fake-key: в обоих случаях 8 passed, 0 skipped, 0 failed.
- Штатный web_search_sync.sh текущей ветки выполнил настоящий запрос с API-ключом: HTTP 200 и сохранённый файл результата (1 результат, --no-snippets). Секреты и пользовательская конфигурация не публикуются.
