### PR TITLE
fix(yandex-wordstat): stop stranding the SA private key in $TMPDIR

### DIFF
--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/common.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/common.sh
@@ -98,14 +98,19 @@ else:
 
 # --- Temp file management ---
 
-# Create secure temp directory
+# Create secure temp directory (0700)
 # Usage: _tmpdir=$(make_secure_tmpdir)
+# The umask is restored before returning, so the directory is 0700 but files
+# written into it follow the caller's umask. A caller that puts secrets there
+# must set its own umask 077 around those writes (see iam_token_get.sh).
+# POSIX sh has no locals: variables are prefixed to avoid clobbering a
+# caller's variable of the same name.
 make_secure_tmpdir() {
-    _old_umask=$(umask)
+    _mstd_old_umask=$(umask)
     umask 077
-    _td=$(mktemp -d "${TMPDIR:-/tmp}/ysa_XXXXXX")
-    umask "$_old_umask"
-    echo "$_td"
+    _mstd_td=$(mktemp -d "${TMPDIR:-/tmp}/ysa_XXXXXX")
+    umask "$_mstd_old_umask"
+    echo "$_mstd_td"
 }
 
 # --- JSON helpers (via python3) ---

--- a/plugins/yandex-search-api/skills/yandex-search-api/scripts/iam_token_get.sh
+++ b/plugins/yandex-search-api/skills/yandex-search-api/scripts/iam_token_get.sh
@@ -46,6 +46,12 @@ check_openssl "$OPENSSL_BIN"
 SECURE_TMP=$(make_secure_tmpdir)
 trap 'rm -rf "$SECURE_TMP"' EXIT INT TERM
 
+# make_secure_tmpdir restores the umask before returning, so set it again here:
+# key.pem, the JWT parts and openssl's signature must land 0600, not 0644.
+# Restored after the last read out of $SECURE_TMP.
+OLD_UMASK=$(umask)
+umask 077
+
 # Extract SA credentials and create JWT via python3
 python3 << PYEOF
 import json, base64, time, os
@@ -104,6 +110,9 @@ SIGNATURE=$(cat "$SECURE_TMP/signature.bin" | b64url_encode)
 # Assemble JWT
 HEADER_PAYLOAD=$(cat "$SECURE_TMP/header_payload.txt")
 JWT="${HEADER_PAYLOAD}.${SIGNATURE}"
+
+# Done with the key material.
+umask "$OLD_UMASK"
 
 # Exchange JWT for IAM token
 IAM_RESPONSE=$(http_request "POST" "$IAM_API_URL" \

--- a/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/common.sh
+++ b/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/common.sh
@@ -286,12 +286,17 @@ print_backend_info() {
 # IAM token — JWT PS256 with SA key (inline-copied from yandex-search-api)
 # ---------------------------------------------------------------------
 
+# Create a 0700 temp directory under $TMPDIR. The umask is restored before
+# returning, so a caller that writes secrets into the directory must set its
+# own umask 077 around those writes (see _iam_token_issue).
+# POSIX sh has no locals: every variable here is prefixed to avoid clobbering
+# a caller's variable of the same name.
 _make_secure_tmpdir() {
-    _old_umask=$(umask)
+    _mstd_old_umask=$(umask)
     umask 077
-    _td=$(mktemp -d "${TMPDIR:-/tmp}/wordstat_XXXXXX")
-    umask "$_old_umask"
-    echo "$_td"
+    _mstd_td=$(mktemp -d "${TMPDIR:-/tmp}/wordstat_XXXXXX")
+    umask "$_mstd_old_umask"
+    echo "$_mstd_td"
 }
 
 _check_openssl() {
@@ -313,9 +318,9 @@ _check_openssl() {
 }
 
 _get_cached_iam_token() {
-    _cf="$WORDSTAT_CACHE_DIR/iam_token.json"
-    [ -f "$_cf" ] || return 0
-    _CACHE_FILE="$_cf" python3 - <<'PYEOF' 2>/dev/null
+    _gcit_cf="$WORDSTAT_CACHE_DIR/iam_token.json"
+    [ -f "$_gcit_cf" ] || return 0
+    _CACHE_FILE="$_gcit_cf" python3 - <<'PYEOF' 2>/dev/null
 import json, os, time
 cf = os.environ["_CACHE_FILE"]
 try:
@@ -329,22 +334,26 @@ except Exception:
 PYEOF
 }
 
+# NOTE: every variable is prefixed _sit_ on purpose. This function is called
+# from _iam_token_issue while that function still owns a temp directory; an
+# unprefixed _tmp here would overwrite the caller's path and strand the
+# private key on disk (that bug shipped once already).
 _save_iam_token() {
-    _tok="$1"
-    _exp="$2"
+    _sit_tok="$1"
+    _sit_exp="$2"
     mkdir -p "$WORDSTAT_CACHE_DIR"
-    _cf="$WORDSTAT_CACHE_DIR/iam_token.json"
-    _old_umask=$(umask)
+    _sit_cf="$WORDSTAT_CACHE_DIR/iam_token.json"
+    _sit_old_umask=$(umask)
     umask 077
-    _tmp="$WORDSTAT_CACHE_DIR/.iam_token_tmp_$$.json"
-    _SAVE_TOKEN="$_tok" _SAVE_EXP="$_exp" _TMP_FILE="$_tmp" python3 - <<'PYEOF'
+    _sit_tmp="$WORDSTAT_CACHE_DIR/.iam_token_tmp_$$.json"
+    _SAVE_TOKEN="$_sit_tok" _SAVE_EXP="$_sit_exp" _TMP_FILE="$_sit_tmp" python3 - <<'PYEOF'
 import json, os
 d = {"iam_token": os.environ["_SAVE_TOKEN"], "expires_at": int(os.environ["_SAVE_EXP"])}
 with open(os.environ["_TMP_FILE"], "w") as f:
     json.dump(d, f)
 PYEOF
-    mv "$_tmp" "$_cf"
-    umask "$_old_umask"
+    mv "$_sit_tmp" "$_sit_cf"
+    umask "$_sit_old_umask"
 }
 
 # Issue a fresh IAM token from the SA key. Echoes token on stdout.
@@ -355,12 +364,19 @@ _iam_token_issue() {
         die_with_help "Service account key file not readable: $WORDSTAT_CLOUD_SA_KEY_PATH"
     fi
 
-    _tmp=$(_make_secure_tmpdir)
+    _iti_tmp=$(_make_secure_tmpdir)
     # shellcheck disable=SC2064
-    trap "rm -rf '$_tmp'" EXIT INT TERM
+    trap "rm -rf '$_iti_tmp'" EXIT INT TERM
+
+    # Every file below (key.pem, the JWT parts, openssl's signature) is written
+    # while umask 077 is in effect, so they land 0600 rather than 0644.
+    # _make_secure_tmpdir restores the umask before it returns, so we set our
+    # own here and restore it on the way out.
+    _iti_old_umask=$(umask)
+    umask 077
 
     # Build JWT header + payload, write key.pem and signing_input.txt
-    _SA_KEY="$WORDSTAT_CLOUD_SA_KEY_PATH" _TMP="$_tmp" python3 - <<'PYEOF' || die_with_help "Failed to build JWT from SA key"
+    _SA_KEY="$WORDSTAT_CLOUD_SA_KEY_PATH" _TMP="$_iti_tmp" python3 - <<'PYEOF' || die_with_help "Failed to build JWT from SA key"
 import json, base64, time, os, sys
 sa_key_file = os.environ["_SA_KEY"]
 tmp_dir = os.environ["_TMP"]
@@ -399,17 +415,17 @@ PYEOF
     "$WORDSTAT_CLOUD_OPENSSL_BIN" dgst -sha256 \
         -sigopt rsa_padding_mode:pss \
         -sigopt rsa_pss_saltlen:-1 \
-        -sign "$_tmp/key.pem" \
-        -out "$_tmp/signature.bin" \
-        "$_tmp/signing_input.txt" 2>/dev/null \
+        -sign "$_iti_tmp/key.pem" \
+        -out "$_iti_tmp/signature.bin" \
+        "$_iti_tmp/signing_input.txt" 2>/dev/null \
         || die_with_help "openssl PS256 signing failed"
 
     _sig=$(python3 -c "
 import base64, sys
-with open('$_tmp/signature.bin', 'rb') as f:
+with open('$_iti_tmp/signature.bin', 'rb') as f:
     print(base64.urlsafe_b64encode(f.read()).rstrip(b'=').decode())
 ")
-    _hp=$(cat "$_tmp/header_payload.txt")
+    _hp=$(cat "$_iti_tmp/header_payload.txt")
     _jwt="${_hp}.${_sig}"
 
     _resp=$(curl -s -X POST "$WORDSTAT_IAM_API" \
@@ -451,13 +467,18 @@ print(f'{tok}|{exp}')
         NO_TOKEN:*)    die_with_help "IAM response missing iamToken" "${_result#NO_TOKEN:}" ;;
     esac
 
-    _tok=$(printf '%s' "$_result" | cut -d'|' -f1)
-    _exp=$(printf '%s' "$_result" | cut -d'|' -f2)
-    _save_iam_token "$_tok" "$_exp"
+    _iti_tok=$(printf '%s' "$_result" | cut -d'|' -f1)
+    _iti_exp=$(printf '%s' "$_result" | cut -d'|' -f2)
 
-    rm -rf "$_tmp"
+    # Drop the key material first: nothing below needs the temp directory, and
+    # doing it here means no later call can clobber $_iti_tmp before the rm.
+    rm -rf "$_iti_tmp"
+    umask "$_iti_old_umask"
     trap - EXIT INT TERM
-    printf '%s' "$_tok"
+
+    _save_iam_token "$_iti_tok" "$_iti_exp"
+
+    printf '%s' "$_iti_tok"
 }
 
 _iam_token_get() {
@@ -728,9 +749,9 @@ _cloud_request() {
     _backoff=2
     while [ "$_attempt" -lt "$_max_attempts" ]; do
         _attempt=$((_attempt + 1))
-        _tmp=$(_make_secure_tmpdir)
-        _resp_file="$_tmp/resp"
-        _status=$(curl -s -o "$_resp_file" -w '%{http_code}' \
+        _cr_tmp=$(_make_secure_tmpdir)
+        _cr_resp_file="$_cr_tmp/resp"
+        _status=$(curl -s -o "$_cr_resp_file" -w '%{http_code}' \
             -X POST "$WORDSTAT_CLOUD_API/$_method" \
             -H "Authorization: Bearer $_tok" \
             -H "Content-Type: application/json" \
@@ -738,8 +759,8 @@ _cloud_request() {
 
         case "$_status" in
             2[0-9][0-9])
-                _normalize_response "$_method" "$_resp_file"
-                rm -rf "$_tmp"
+                _normalize_response "$_method" "$_cr_resp_file"
+                rm -rf "$_cr_tmp"
                 return 0
                 ;;
             401)
@@ -747,33 +768,33 @@ _cloud_request() {
                 if [ "$_attempt" = "1" ]; then
                     rm -f "$WORDSTAT_CACHE_DIR/iam_token.json"
                     _tok=$(_iam_token_issue)
-                    rm -rf "$_tmp"
+                    rm -rf "$_cr_tmp"
                     continue
                 fi
-                _err=$(cat "$_resp_file" 2>/dev/null)
-                rm -rf "$_tmp"
+                _err=$(cat "$_cr_resp_file" 2>/dev/null)
+                rm -rf "$_cr_tmp"
                 die_with_help "Cloud Wordstat 401 Unauthorized after token refresh" "$_err"
                 ;;
             403)
-                _err=$(cat "$_resp_file" 2>/dev/null)
-                rm -rf "$_tmp"
+                _err=$(cat "$_cr_resp_file" 2>/dev/null)
+                rm -rf "$_cr_tmp"
                 die_with_help "Cloud Wordstat 403 Forbidden" \
                     "Check that your service account has the role 'search-api.webSearch.user' on folder $WORDSTAT_CLOUD_FOLDER_ID. Raw: $_err"
                 ;;
             5[0-9][0-9]|000)
                 if [ "$_attempt" -lt "$_max_attempts" ]; then
-                    rm -rf "$_tmp"
+                    rm -rf "$_cr_tmp"
                     sleep "$_backoff"
                     _backoff=$((_backoff * 2))
                     continue
                 fi
-                _err=$(cat "$_resp_file" 2>/dev/null)
-                rm -rf "$_tmp"
+                _err=$(cat "$_cr_resp_file" 2>/dev/null)
+                rm -rf "$_cr_tmp"
                 die_with_help "Cloud Wordstat $_status after $_max_attempts retries" "$_err"
                 ;;
             *)
-                _err=$(cat "$_resp_file" 2>/dev/null)
-                rm -rf "$_tmp"
+                _err=$(cat "$_cr_resp_file" 2>/dev/null)
+                rm -rf "$_cr_tmp"
                 die_with_help "Cloud Wordstat HTTP $_status" "$_err"
                 ;;
         esac

--- a/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/tests/test_iam_tmpdir_cleanup.sh
+++ b/plugins/yandex-wordstat/skills/yandex-wordstat/scripts/tests/test_iam_tmpdir_cleanup.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+# Regression test: issuing an IAM token must not leave the service-account
+# private key behind in $TMPDIR.
+#
+# The original bug: _save_iam_token assigned the unprefixed global $_tmp, so by
+# the time _iam_token_issue ran `rm -rf "$_tmp"` the variable no longer pointed
+# at the secure temp directory, and the `trap - EXIT INT TERM` on the next line
+# disarmed the trap that still held the correct path. Every token issue left a
+# $TMPDIR/wordstat_XXXXXX/key.pem on disk forever.
+#
+# No network: openssl and curl are replaced by stubs on PATH.
+
+set -e
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+SKILL_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+
+# Sandbox: our own TMPDIR so we count only dirs this test creates, and the
+# user's real $TMPDIR is never touched.
+SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/wsiamtest_XXXXXX")
+trap 'rm -rf "$SANDBOX"' EXIT INT TERM
+
+TMPDIR="$SANDBOX/tmp"
+mkdir -p "$TMPDIR"
+export TMPDIR
+
+BIN="$SANDBOX/bin"
+mkdir -p "$BIN"
+
+# --- stub openssl -----------------------------------------------------------
+# `version` must not look like LibreSSL/1.0 or _check_openssl dies.
+# `dgst` records the mode of key.pem (so we can assert 0600 while the file
+# still exists) and writes a fake signature to the -out path.
+cat > "$BIN/openssl" <<'STUB'
+#!/bin/sh
+case "$1" in
+    version) echo "OpenSSL 3.0.0 test-stub"; exit 0 ;;
+esac
+_out=""
+_key=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -out)   _out="$2"; shift 2 ;;
+        -sign)  _key="$2"; shift 2 ;;
+        *)      shift ;;
+    esac
+done
+[ -n "$_key" ] && ls -l "$_key" | cut -d' ' -f1 > "$WS_TEST_KEYMODE_FILE"
+printf 'fake-signature-bytes' > "$_out"
+exit 0
+STUB
+chmod +x "$BIN/openssl"
+
+# --- stub curl --------------------------------------------------------------
+cat > "$BIN/curl" <<'STUB'
+#!/bin/sh
+# _iam_token_issue posts the JWT and expects {"iamToken":..,"expiresAt":..}
+echo '{"iamToken":"test-iam-token-xyz","expiresAt":"2099-01-01T00:00:00Z"}'
+exit 0
+STUB
+chmod +x "$BIN/curl"
+
+PATH="$BIN:$PATH"
+export PATH
+
+WS_TEST_KEYMODE_FILE="$SANDBOX/keymode"
+export WS_TEST_KEYMODE_FILE
+
+# --- fake SA key ------------------------------------------------------------
+# openssl is stubbed, so the private_key body only has to be a string.
+cat > "$SANDBOX/sa_key.json" <<'SAKEY'
+{
+  "id": "ajetestkeyid000000000",
+  "service_account_id": "ajetestsaid0000000000",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nTEST-NOT-A-REAL-KEY\n-----END PRIVATE KEY-----\n"
+}
+SAKEY
+
+# --- load common.sh with the cache pointed at the sandbox -------------------
+WORDSTAT_SCRIPT_DIR="$SCRIPTS_DIR"
+WORDSTAT_SKILL_DIR="$SKILL_DIR"
+WORDSTAT_CACHE_DIR="$SANDBOX/cache"
+export WORDSTAT_SCRIPT_DIR WORDSTAT_SKILL_DIR WORDSTAT_CACHE_DIR
+# shellcheck disable=SC1091
+. "$SCRIPTS_DIR/common.sh"
+
+WORDSTAT_BACKEND="cloud"
+WORDSTAT_CLOUD_FOLDER_ID="b1g-test-folder"
+WORDSTAT_CLOUD_SA_KEY_PATH="$SANDBOX/sa_key.json"
+WORDSTAT_CLOUD_OPENSSL_BIN="$BIN/openssl"
+WORDSTAT_IAM_API="http://127.0.0.1:0/stubbed"
+
+# find, not a glob: zsh aborts on an unmatched glob, and the harness should
+# run under whatever /bin/sh (or shell) the caller has.
+count_leftovers() {
+    find "$TMPDIR" -maxdepth 1 -name 'wordstat_*' 2>/dev/null | wc -l | tr -d ' \n'
+}
+
+fail() {
+    echo "  FAIL: $1"
+    echo "  leftovers in $TMPDIR:"
+    ls -la "$TMPDIR" || true
+    exit 1
+}
+
+# --- 1. direct call: _iam_token_issue must clean up ------------------------
+before=$(count_leftovers)
+tok=$(_iam_token_issue)
+after=$(count_leftovers)
+
+[ "$tok" = "test-iam-token-xyz" ] || fail "expected stub token, got '$tok'"
+[ "$before" = "0" ] || fail "sandbox TMPDIR was not clean before the call ($before)"
+[ "$after" = "0" ] || fail "_iam_token_issue leaked $after wordstat_* dir(s) holding key.pem"
+echo "  ok: _iam_token_issue leaves no wordstat_* dir"
+
+# --- 2. the key.pem it wrote was 0600, not 0644 ----------------------------
+mode=$(cat "$WS_TEST_KEYMODE_FILE" 2>/dev/null || echo "")
+case "$mode" in
+    -rw-------*) echo "  ok: key.pem was 0600 while on disk" ;;
+    "")          fail "openssl stub never saw key.pem" ;;
+    *)           fail "key.pem was '$mode', expected -rw------- (umask 077 must stay in effect)" ;;
+esac
+
+# --- 3. the cached token file is 0600 --------------------------------------
+# _save_iam_token now runs after _iam_token_issue restores its umask, so it
+# must still be setting umask 077 itself.
+cache_mode=$(ls -l "$WORDSTAT_CACHE_DIR/iam_token.json" | cut -d' ' -f1)
+case "$cache_mode" in
+    -rw-------*) echo "  ok: cached iam_token.json is 0600" ;;
+    *)           fail "cached iam_token.json was '$cache_mode', expected -rw-------" ;;
+esac
+
+# --- 4. production path: _iam_token_get inside a command substitution -------
+# This is how _cloud_request calls it. The cold-cache branch runs
+# _iam_token_issue inside a subshell, where the EXIT trap behaves differently.
+rm -rf "$WORDSTAT_CACHE_DIR"
+tok2=$(_iam_token_get)
+after2=$(count_leftovers)
+
+[ "$tok2" = "test-iam-token-xyz" ] || fail "expected stub token from _iam_token_get, got '$tok2'"
+[ "$after2" = "0" ] || fail "_iam_token_get (cold cache) leaked $after2 wordstat_* dir(s)"
+echo "  ok: _iam_token_get with a cold cache leaves no wordstat_* dir"
+
+# --- 5. warm cache issues nothing and still leaks nothing -------------------
+tok3=$(_iam_token_get)
+after3=$(count_leftovers)
+[ "$tok3" = "test-iam-token-xyz" ] || fail "warm cache returned '$tok3'"
+[ "$after3" = "0" ] || fail "_iam_token_get (warm cache) leaked $after3 wordstat_* dir(s)"
+echo "  ok: _iam_token_get with a warm cache leaves no wordstat_* dir"
+
+# --- 6. error path: the trap must still clean up ----------------------------
+# Make the IAM exchange fail (curl returns empty) -> die_with_help -> exit 1
+# inside the command substitution's subshell. The EXIT trap is the only thing
+# that can remove the directory there.
+cat > "$BIN/curl" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+chmod +x "$BIN/curl"
+
+rm -rf "$WORDSTAT_CACHE_DIR"
+tok4=$( _iam_token_get 2>/dev/null ) || true
+after4=$(count_leftovers)
+[ -z "$tok4" ] || fail "expected no token on the failure path, got '$tok4'"
+[ "$after4" = "0" ] || fail "failure path leaked $after4 wordstat_* dir(s) holding key.pem"
+echo "  ok: failing token issue leaves no wordstat_* dir (EXIT trap fires)"
+
+echo "  all IAM tmpdir cleanup assertions passed"


### PR DESCRIPTION
## Problem

Every IAM token issue left `$TMPDIR/wordstat_XXXXXX/key.pem` — a copy of the service-account private key — on disk permanently. 14 accumulated copies were found on one machine.

Pre-existing on `main`; not introduced by #111 or #112.

## Root cause

`_save_iam_token` assigns the unprefixed global `_tmp`. POSIX sh has no locals, so it overwrote the path its caller `_iam_token_issue` was still holding:

```sh
_tmp=$(_make_secure_tmpdir)          # _tmp = /…/wordstat_XXXXXX   ← key.pem lives here
trap "rm -rf '$_tmp'" EXIT INT TERM  # expanded now, holds the CORRECT path
…
_save_iam_token "$_tok" "$_exp"      # ← sets _tmp="$CACHE_DIR/.iam_token_tmp_$$.json"
rm -rf "$_tmp"                       # removes the already-renamed cache file — no-op
trap - EXIT INT TERM                 # disarms the trap that DID hold the right path
```

The subshell was not the culprit — traps behave normally, and the trap does fire on error paths (`die_with_help` exits). It never fires on the success path only because the code explicitly removes it one line after the ineffective `rm`.

## Changes

- Prefix each helper's variables per function (`_iti_`, `_sit_`, `_gcit_`, `_mstd_`, `_cr_`), the project's stand-in for `local`. This removes the collision class rather than this one instance.
- Drop the temp directory *before* calling `_save_iam_token`, so nothing can clobber the path between creation and removal.
- Keep `umask 077` in effect across the key-material section, so `key.pem`, the JWT parts and openssl's `signature.bin` land 0600 instead of 0644.
- Same umask hardening in `yandex-search-api`. That skill does **not** leak the directory — `SECURE_TMP` is never shadowed and its trap is never disarmed, verified by a stubbed run — but it wrote `key.pem` 0644 too.

`telegraph-publisher` and `reddit-skill` use similar shapes; neither leaks and neither handles key material.

## Test

`scripts/tests/test_iam_tmpdir_cleanup.sh` — stubs `openssl`/`curl` on `PATH`, sandboxes `TMPDIR`, no network and no real key. Asserts no leftover directory after a direct issue, after `_iam_token_get` on a cold and a warm cache, and after a *failing* issue (proving the EXIT trap fires), plus the 0600 modes of `key.pem` and the cached token.

Suite: 5 passed, 0 failed. Passes under sh/dash/bash/zsh. Against `main` the new case exits 1 with `leaked 1 wordstat_* dir(s) holding key.pem`.

## Note for whoever merges

Existing leaked copies are not cleaned up retroactively:

```sh
find "${TMPDIR:-/tmp}" -maxdepth 1 -type d -name 'wordstat_*' -exec rm -rf {} +
```

The affected key was readable by any local user across many token issues, so it is worth rotating rather than only deleting the copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)