### PR TITLE
fix(codex-review): pass the reasoning effort to the call that opens the session

### DIFF
--- a/plugins/codex-review/.claude-plugin/plugin.json
+++ b/plugins/codex-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review",
   "description": "Cross-agent review workflow: Claude implements, Codex reviews",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Polyakov"
   },

--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -175,10 +175,24 @@ STATE_DIR="$(get_state_dir)"
 MAX_ITERATIONS="${MAX_ITER:-$CODEX_MAX_ITERATIONS}"
 SESSION_ID="$(get_effective_session_id)"
 
-# --- Build yolo flags (as array to avoid word splitting) ---
+# --- Build codex exec flags (as arrays to avoid word splitting) ---
+# Every codex exec call in this script shares these, so a session cannot be
+# opened under one model or reasoning effort and then reviewed under another.
 YOLO_FLAG=()
 if [[ "$CODEX_YOLO" == "true" ]]; then
     YOLO_FLAG=("--yolo")
+fi
+
+MODEL_FLAG=()
+if [[ -n "$CODEX_MODEL" ]]; then
+    MODEL_FLAG=("--model" "$CODEX_MODEL")
+fi
+
+# codex exec has no dedicated flag for this; the value reaches the CLI as a
+# config override and is parsed as TOML, hence the inner quotes.
+REASONING_FLAG=()
+if [[ -n "$CODEX_REASONING_EFFORT" ]]; then
+    REASONING_FLAG=("-c" "model_reasoning_effort=\"$CODEX_REASONING_EFFORT\"")
 fi
 
 # --- Reviewer role prompt (reusable base) ---
@@ -611,13 +625,9 @@ cmd_init() {
     echo "Creating Codex session..." >&2
     printf '\033[1;33m>>> Monitor: tail -f %s\033[0m\n' "$log_file" >&2
 
-    local MODEL_FLAG=()
-    if [[ -n "$CODEX_MODEL" ]]; then
-        MODEL_FLAG=("--model" "$CODEX_MODEL")
-    fi
-
     CODEX_REVIEWER=1 codex exec \
         "${MODEL_FLAG[@]}" \
+        "${REASONING_FLAG[@]}" \
         "${YOLO_FLAG[@]}" \
         -o "$output_file" \
         - < "$prompt_file" > "$log_file" 2>&1 || {
@@ -735,16 +745,6 @@ cmd_review() {
 
     echo "Sending $phase for review (iteration ${next_iteration}/${MAX_ITERATIONS})..." >&2
     printf '\033[1;33m>>> Monitor: tail -f %s\033[0m\n' "$log_file" >&2
-
-    local MODEL_FLAG=()
-    if [[ -n "$CODEX_MODEL" ]]; then
-        MODEL_FLAG=("--model" "$CODEX_MODEL")
-    fi
-
-    local REASONING_FLAG=()
-    if [[ -n "$CODEX_REASONING_EFFORT" ]]; then
-        REASONING_FLAG=("-c" "model_reasoning_effort=\"$CODEX_REASONING_EFFORT\"")
-    fi
 
     CODEX_REVIEWER=1 codex exec \
         "${MODEL_FLAG[@]}" \

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -14,6 +14,7 @@ test/
 ├── test-integration.sh         # path-contract tests (hook ↔ state dir)
 ├── test-description-file.sh    # --description-file, per-attempt logs, saved request
 ├── test-severity-calibration.sh # severity scale, finding headings, verdict threshold
+├── test-exec-flags.sh          # model and reasoning effort on every codex exec call
 ├── test-e2e.sh                 # opt-in end-to-end with real codex / claude
 └── test-fixtures/              # plan markdown fixtures used by test-e2e.sh
     ├── approve_plan.md         # trivial plan → APPROVED
@@ -175,6 +176,34 @@ Run:
 sh plugins/codex-review/test/test-severity-calibration.sh
 ```
 
+## test-exec-flags.sh
+
+Covers the flags `codex-review.sh` puts on every `codex exec` call.
+
+Scenarios:
+
+1. `CODEX_MODEL` and `CODEX_REASONING_EFFORT` reach the call that opens the
+   session as `--model <name>` and `-c model_reasoning_effort="<effort>"`, and
+   the review that follows carries the same pair.
+2. The two call sites open with an identical flag block — everything up to
+   `-o`, where the per-call arguments begin. A flag added to one site and not
+   the other fails here, which is what keeps a session from being created under
+   one setting and reviewed under another.
+3. With neither setting configured, no `--model` and no `-c` are passed at all,
+   and no empty argument goes out in their place.
+
+Does **not** require the `codex` binary — a stub on `PATH` records the argv of
+every exec call, one argument per line, as `argv-<N>.txt` beside the repo. The
+`codex --version` probe `common.sh` runs before every review is not an exec
+call and is not recorded, so `argv-1.txt` is the session call and `argv-2.txt`
+the review.
+
+Run:
+
+```sh
+sh plugins/codex-review/test/test-exec-flags.sh
+```
+
 ## test-e2e.sh
 
 Opt-in end-to-end tests that exercise real `codex` / `claude` CLIs.
@@ -253,5 +282,5 @@ scenario — as an `init` task and as a code description, not as plans:
 
 ## Exit codes
 
-All five scripts exit `0` on success and `1` if any assertion failed.
+All six scripts exit `0` on success and `1` if any assertion failed.
 `test-e2e.sh` additionally exits `0` (skip) when `CODEX_E2E` is not set.

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -169,6 +169,9 @@ stdin and writes the verdict; the assertions read the prompt copy the run keeps
 as `codex-<phase>-<N>.prompt.md`. A `fail-next` marker file makes the stub fail
 one review call, and only a review call: `common.sh` probes `codex --version`
 before every run, and failing that probe would abort before any review ran.
+`run_review` clears every setting `load_config` reads, so an exported
+`CODEX_SEVERITY_CALIBRATION` or `CODEX_MAX_ITERATIONS` cannot decide the
+outcome of an assertion.
 
 Run:
 
@@ -197,6 +200,10 @@ every exec call, one argument per line, as `argv-<N>.txt` beside the repo. The
 `codex --version` probe `common.sh` runs before every review is not an exec
 call and is not recorded, so `argv-1.txt` is the session call and `argv-2.txt`
 the review.
+
+`run_review` clears every setting `load_config` reads before each run, so the
+assertions answer to the repo's own `config.env` and not to a `CODEX_MODEL` or
+`CODEX_REASONING_EFFORT` exported on the machine running the suite.
 
 Run:
 

--- a/plugins/codex-review/test/test-exec-flags.sh
+++ b/plugins/codex-review/test/test-exec-flags.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+# Tests for the flags every `codex exec` call carries.
+#
+# Covers:
+#   - the configured model and reasoning effort reach the call that opens the
+#     session, not only the calls that send reviews
+#   - both call sites open with the same flags, so a session cannot be created
+#     under one setting and reviewed under another
+#   - an unset model or reasoning effort is passed as nothing at all, rather
+#     than as an empty value
+#
+# Does NOT require the real `codex` binary: a stub on PATH records the argv of
+# every exec call, so the assertions read what the CLI would have received.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROD_SCRIPTS="$SCRIPT_DIR/../skills/codex-review/scripts"
+REVIEW_CMD="$PROD_SCRIPTS/codex-review.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+    printf "  PASS: %s\n" "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf "  FAIL: %s\n" "$1"
+    [ -n "$2" ] && printf "    %s\n" "$2"
+}
+
+# The stub writes one argument per line, so a whole argument is matched as a
+# whole line — `-c` must not be satisfied by a `-c` sitting inside some other
+# string, and `--model` must not be satisfied by `--model-something`.
+assert_argv_has() {
+    # name, argv file, exact argument
+    if [ ! -f "$2" ]; then
+        fail "$1" "no call recorded: $2"
+        return
+    fi
+    if grep -qxF -- "$3" "$2"; then
+        pass "$1"
+    else
+        fail "$1" "expected the call to carry: $3"
+    fi
+}
+
+assert_argv_lacks() {
+    # name, argv file, exact argument
+    if [ ! -f "$2" ]; then
+        fail "$1" "no call recorded: $2"
+        return
+    fi
+    if grep -qxF -- "$3" "$2"; then
+        fail "$1" "expected the call NOT to carry: $3"
+    else
+        pass "$1"
+    fi
+}
+
+# --- Repo with a codex stub on PATH ------------------------------------------
+make_repo() {
+    repo="$(mktemp -d)"
+    git -C "$repo" init -q
+    mkdir -p "$repo/bin"
+    cat > "$repo/bin/codex" <<'STUB'
+#!/bin/sh
+# Test stub: records the argv of every exec call, one argument per line, then
+# reads the prompt from stdin and writes APPROVED to the -o target.
+# `common.sh` probes `codex --version` before every run; that probe is not an
+# exec call and is not recorded, so the numbering counts review calls only.
+_dir="$(dirname "$0")/.."
+if [ "$1" = "exec" ]; then
+    _n=1
+    while [ -f "$_dir/argv-$_n.txt" ]; do _n=$((_n + 1)); done
+    for _a in "$@"; do printf '%s\n' "$_a"; done > "$_dir/argv-$_n.txt"
+fi
+out=""
+from_stdin=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        -) from_stdin=1; shift ;;
+        *) shift ;;
+    esac
+done
+[ -n "$from_stdin" ] && cat >/dev/null
+[ -n "$out" ] && printf 'APPROVED\n' > "$out"
+printf 'session sess_teststub01 ready\n'
+exit 0
+STUB
+    chmod +x "$repo/bin/codex"
+    echo "$repo"
+}
+
+run_review() {
+    # repo, then codex-review.sh arguments. Never fails the suite on its own.
+    _repo="$1"
+    shift
+    (cd "$_repo" && PATH="$_repo/bin:$PATH" CODEX_HOME="$_repo/codex-home" \
+        bash "$REVIEW_CMD" "$@" >/dev/null 2>&1) || true
+}
+
+argv_file() {
+    # repo, call number — the argv of the Nth exec call the run made
+    printf '%s/argv-%s.txt' "$1" "$2"
+}
+
+# The flags a call opens with are everything before `-o`, which is where the
+# per-call arguments start: the output path, then `resume <id>` on a review.
+# Comparing that block across the two call sites is what catches a flag added
+# to one of them and not the other.
+flags_block() {
+    sed -n '1,/^-o$/p' "$1"
+}
+
+echo "=== The configured model and effort reach every call ==="
+
+REPO="$(make_repo)"
+mkdir -p "$REPO/.codex-review"
+cat > "$REPO/.codex-review/config.env" <<'CFG'
+CODEX_MODEL=stub-model
+CODEX_REASONING_EFFORT=xhigh
+CFG
+printf 'A task.\n' > "$REPO/task.md"
+printf 'What changed: nothing much.\n' > "$REPO/desc.md"
+
+# Opening the session is the first exec call, the review that follows is the
+# second — both are made against the same config.
+run_review "$REPO" init --description-file "$REPO/task.md"
+run_review "$REPO" code --description-file "$REPO/desc.md"
+
+INIT_ARGV="$(argv_file "$REPO" 1)"
+REVIEW_ARGV="$(argv_file "$REPO" 2)"
+
+assert_argv_has "the session is opened with the configured model" \
+    "$INIT_ARGV" "--model"
+assert_argv_has "the model name reaches the call that opens the session" \
+    "$INIT_ARGV" "stub-model"
+assert_argv_has "the session is opened with a config override" \
+    "$INIT_ARGV" "-c"
+assert_argv_has "the configured effort reaches the call that opens the session" \
+    "$INIT_ARGV" 'model_reasoning_effort="xhigh"'
+
+assert_argv_has "the review carries the configured model" \
+    "$REVIEW_ARGV" "stub-model"
+assert_argv_has "the review carries the configured effort" \
+    "$REVIEW_ARGV" 'model_reasoning_effort="xhigh"'
+
+if [ -f "$INIT_ARGV" ] && [ -f "$REVIEW_ARGV" ] &&
+    [ "$(flags_block "$INIT_ARGV")" = "$(flags_block "$REVIEW_ARGV")" ]; then
+    pass "both calls open with the same flags"
+else
+    fail "both calls open with the same flags" \
+        "session: $(flags_block "$INIT_ARGV" | tr '\n' ' ')| review: $(flags_block "$REVIEW_ARGV" | tr '\n' ' ')"
+fi
+
+rm -rf "$REPO"
+
+echo "=== An unset setting is passed as nothing ==="
+
+REPO="$(make_repo)"
+printf 'A task.\n' > "$REPO/task.md"
+printf 'What changed: nothing much.\n' > "$REPO/desc.md"
+
+run_review "$REPO" init --description-file "$REPO/task.md"
+run_review "$REPO" code --description-file "$REPO/desc.md"
+
+INIT_ARGV="$(argv_file "$REPO" 1)"
+REVIEW_ARGV="$(argv_file "$REPO" 2)"
+
+assert_argv_lacks "no model flag when no model is configured" \
+    "$INIT_ARGV" "--model"
+assert_argv_lacks "no empty model name is passed" \
+    "$INIT_ARGV" ""
+assert_argv_lacks "no config override when no effort is configured" \
+    "$INIT_ARGV" "-c"
+assert_argv_lacks "the review passes no model flag either" \
+    "$REVIEW_ARGV" "--model"
+assert_argv_lacks "the review passes no config override either" \
+    "$REVIEW_ARGV" "-c"
+
+rm -rf "$REPO"
+
+echo ""
+echo "PASS: $PASS  FAIL: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/plugins/codex-review/test/test-exec-flags.sh
+++ b/plugins/codex-review/test/test-exec-flags.sh
@@ -100,8 +100,17 @@ run_review() {
     # repo, then codex-review.sh arguments. Never fails the suite on its own.
     _repo="$1"
     shift
-    (cd "$_repo" && PATH="$_repo/bin:$PATH" CODEX_HOME="$_repo/codex-home" \
-        bash "$REVIEW_CMD" "$@" >/dev/null 2>&1) || true
+    (
+        # Only the repo's own `.codex-review/config.env` may decide what a run
+        # sees. Every setting `load_config` reads is cleared first, so a value
+        # exported on the machine running the suite cannot answer an assertion
+        # that was written about a repo which configures nothing.
+        unset CODEX_MODEL CODEX_REASONING_EFFORT CODEX_MAX_ITERATIONS \
+              CODEX_YOLO CODEX_SESSION_ID AUTO_REVIEW CODEX_REVIEWER_PROMPT \
+              CODEX_PLAN_GUIDE CODEX_CODE_GUIDE CODEX_SEVERITY_CALIBRATION
+        cd "$_repo" && PATH="$_repo/bin:$PATH" CODEX_HOME="$_repo/codex-home" \
+            bash "$REVIEW_CMD" "$@" >/dev/null 2>&1
+    ) || true
 }
 
 argv_file() {

--- a/plugins/codex-review/test/test-severity-calibration.sh
+++ b/plugins/codex-review/test/test-severity-calibration.sh
@@ -114,8 +114,17 @@ run_review() {
     # repo, then codex-review.sh arguments. Never fails the suite on its own.
     _repo="$1"
     shift
-    (cd "$_repo" && PATH="$_repo/bin:$PATH" CODEX_HOME="$_repo/codex-home" \
-        bash "$REVIEW_CMD" "$@" >/dev/null 2>&1) || true
+    (
+        # Only the repo's own `.codex-review/config.env` may decide what a run
+        # sees. Every setting `load_config` reads is cleared first, so a value
+        # exported on the machine running the suite cannot answer an assertion
+        # that was written about a repo which configures nothing.
+        unset CODEX_MODEL CODEX_REASONING_EFFORT CODEX_MAX_ITERATIONS \
+              CODEX_YOLO CODEX_SESSION_ID AUTO_REVIEW CODEX_REVIEWER_PROMPT \
+              CODEX_PLAN_GUIDE CODEX_CODE_GUIDE CODEX_SEVERITY_CALIBRATION
+        cd "$_repo" && PATH="$_repo/bin:$PATH" CODEX_HOME="$_repo/codex-home" \
+            bash "$REVIEW_CMD" "$@" >/dev/null 2>&1
+    ) || true
 }
 
 state_dir() {


### PR DESCRIPTION
## Problem

`CODEX_REASONING_EFFORT` from `.codex-review/config.env` reaches every review but not `init`. `cmd_init` built its own `MODEL_FLAG` and never passed `-c model_reasoning_effort=...`, so the session was created under whatever `model_reasoning_effort` sits in the global `~/.codex/config.toml`.

The effect that hurts: when the global value is one the pinned `CODEX_MODEL` does not accept, `init` dies on a 400 from the API while `plan` and `code` keep working on the very same config — and nothing in the output points at the cause.

`CODEX_REASONING_EFFORT=high` ships in `config/defaults.env.example`, so this reaches anyone who started from the shipped defaults.

## Fix

`MODEL_FLAG` and `REASONING_FLAG` are built once beside `YOLO_FLAG` and shared by both `codex exec` call sites, instead of being rebuilt per command. The two lists can no longer drift apart, which is the root cause rather than the missing flag itself.

`codex exec` (0.148.0) has no dedicated flag for reasoning effort — `-c model_reasoning_effort="..."` is the only route, and the value is parsed as TOML. That is the form `cmd_review` already used.

## Regression cover

`test/test-exec-flags.sh` puts a stub `codex` on `PATH` that records the argv of every exec call, and asserts:

- the configured model and effort reach the call that opens the session, not only the review;
- both call sites open with an identical flag block — everything up to `-o` — so a flag added to one site and not the other fails here;
- with neither setting configured, no `--model` and no `-c` go out, and no empty argument takes their place.

Run against the unfixed script, the suite fails on exactly those points.

Offline suite, all green: integration 8, auto-approve 48, description-file 81, severity-calibration 47, exec-flags 12. `shellcheck` clean on both touched shell files.

Version 1.4.0 → 1.4.1.

## Relation to #110

The bug was reported in #110. That branch is based on 1.2.1 and no longer merges. This supersedes it: same root-cause fix, rebased on current `main`, with the regression cover the discussion there asked for. The original author is credited on the commit.
