### PR TITLE
docs(codex-review): remove unsupported session list command

### DIFF
--- a/plugins/codex-review/skills/codex-review/README.md
+++ b/plugins/codex-review/skills/codex-review/README.md
@@ -142,8 +142,6 @@ CODEX_YOLO=true
 CODEX_SESSION_ID=sess_ваш_id
 ```
 
-Узнать id: `codex session list`
-
 Альтернативно — через CLI: `bash scripts/codex-state.sh set session_id sess_ваш_id`
 
 После этого команды `plan` и `code` будут отправлять ревью в эту сессию через `resume`.


### PR DESCRIPTION
Удалена неподдерживаемая команда codex session list из README скилла codex-review. Логика скилла не менялась.

Проверки:
- проверка структуры скилла прошла;
- git diff --check прошёл;
- отдельное ревью Codex не нашло замечаний.

Closes #32