### PR TITLE
perf(codex-review): переиспользовать каталог состояния и читать его одним снимком

### DIFF
--- a/plugins/codex-review/.claude-plugin/plugin.json
+++ b/plugins/codex-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review",
   "description": "Cross-agent review workflow: Claude implements, Codex reviews",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Polyakov"
   },

--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -167,10 +167,12 @@ if [[ "$COMMAND" == "init" ]]; then
 fi
 
 # --- Load config & state ---
-load_config
+REVIEW_ROOT="$(get_review_root)"
+load_config "$REVIEW_ROOT"
 check_codex_installed
 
-STATE_DIR="$(get_state_dir)"
+STATE_DIR="$(get_state_dir "$REVIEW_ROOT")"
+unset REVIEW_ROOT
 
 MAX_ITERATIONS="${MAX_ITER:-$CODEX_MAX_ITERATIONS}"
 SESSION_ID="$(get_effective_session_id)"

--- a/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
@@ -8,7 +8,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/common.sh"
 
-STATE_DIR="$(get_state_dir)"
+REVIEW_ROOT="$(get_review_root)"
+STATE_DIR="$(get_state_dir "$REVIEW_ROOT")"
 STATE_FILE="$STATE_DIR/state.json"
 
 cmd_show() {
@@ -91,7 +92,8 @@ cmd_set() {
 }
 
 # --- Load config for defaults ---
-load_config
+load_config "$REVIEW_ROOT"
+unset REVIEW_ROOT
 
 # --- Main ---
 case "${1:-}" in

--- a/plugins/codex-review/skills/codex-review/scripts/common.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/common.sh
@@ -58,9 +58,14 @@ get_review_root() {
 }
 
 # --- State directory (per-branch isolation inside .codex-review/) ---
+# An optional root lets one command resolve .codex-review once for config + state.
+# Entry scripts pass that argument; standalone helpers intentionally omit it.
+# shellcheck disable=SC2120
 get_state_dir() {
-    local review_root
-    review_root="$(get_review_root)"
+    local review_root="${1:-}"
+    if [[ -z "$review_root" ]]; then
+        review_root="$(get_review_root)"
+    fi
     local branch
     branch="$(get_branch_slug)"
     local state_dir="$review_root/$branch"
@@ -79,9 +84,12 @@ ensure_state_dir() {
 }
 
 # --- Load config (shared config.env → env vars → defaults) ---
+# Accepts the same optional pre-resolved root as get_state_dir.
 load_config() {
-    local review_root
-    review_root="$(get_review_root)"
+    local review_root="${1:-}"
+    if [[ -z "$review_root" ]]; then
+        review_root="$(get_review_root)"
+    fi
     local config_file="$review_root/config.env"
 
     if [[ -f "$config_file" ]]; then
@@ -336,12 +344,11 @@ generate_archive_summary() {
 
     # Read from state.json (still in state_dir at this point)
     if [[ -f "$state_dir/state.json" ]]; then
-        task_desc="$(grep -o '"task_description"[[:space:]]*:[[:space:]]*"[^"]*"' "$state_dir/state.json" \
-            | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//')"
-        session_id="$(grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$state_dir/state.json" \
-            | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//')"
-        last_status="$(grep -o '"last_review_status"[[:space:]]*:[[:space:]]*"[^"]*"' "$state_dir/state.json" \
-            | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//')"
+        local state_json
+        state_json="$(<"$state_dir/state.json")"
+        task_desc="$(read_state_field "task_description" "$state_json")"
+        session_id="$(read_state_field "session_id" "$state_json")"
+        last_status="$(read_state_field "last_review_status" "$state_json")"
     fi
 
     # Read final verdict via format-agnostic helper

--- a/plugins/codex-review/skills/codex-review/scripts/common.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/common.sh
@@ -69,6 +69,15 @@ get_state_dir() {
     echo "$state_dir"
 }
 
+# --- State directory for the current command ---
+# Entry scripts resolve STATE_DIR once. Reuse it so helpers do not repeat git,
+# mkdir and touch calls; standalone callers still get the normal fallback.
+ensure_state_dir() {
+    if [[ -z "${STATE_DIR:-}" ]]; then
+        STATE_DIR="$(get_state_dir)"
+    fi
+}
+
 # --- Load config (shared config.env → env vars → defaults) ---
 load_config() {
     local review_root
@@ -92,40 +101,55 @@ load_config() {
 }
 
 # --- Read a field from state.json (no jq dependency) ---
+# An optional second argument supplies an in-memory snapshot. This lets callers
+# that need several fields read the file once without maintaining a stale cache.
 read_state_field() {
     local field="$1"
-    local state_dir
-    state_dir="$(get_state_dir)"
-    local state_file="$state_dir/state.json"
+    local state_json
 
-    if [[ ! -f "$state_file" ]]; then
-        echo ""
-        return
+    if [[ $# -ge 2 ]]; then
+        state_json="$2"
+    else
+        ensure_state_dir
+        local state_file="$STATE_DIR/state.json"
+        if [[ ! -f "$state_file" ]]; then
+            echo ""
+            return
+        fi
+        state_json="$(<"$state_file")"
     fi
 
-    grep -o "\"$field\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$state_file" \
-        | head -1 \
-        | sed 's/.*:[[:space:]]*"//' \
-        | tr -d '"'
+    local pattern="\"${field}\"[[:space:]]*:[[:space:]]*\"([^\"]*)\""
+    if [[ "$state_json" =~ $pattern ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    else
+        echo ""
+    fi
 }
 
 # --- Read numeric field from state.json ---
 read_state_number() {
     local field="$1"
-    local state_dir
-    state_dir="$(get_state_dir)"
-    local state_file="$state_dir/state.json"
+    local state_json
 
-    if [[ ! -f "$state_file" ]]; then
-        echo "0"
-        return
+    if [[ $# -ge 2 ]]; then
+        state_json="$2"
+    else
+        ensure_state_dir
+        local state_file="$STATE_DIR/state.json"
+        if [[ ! -f "$state_file" ]]; then
+            echo "0"
+            return
+        fi
+        state_json="$(<"$state_file")"
     fi
 
-    local val
-    val=$(grep -o "\"$field\"[[:space:]]*:[[:space:]]*[0-9]*" "$state_file" \
-        | head -1 \
-        | sed 's/.*:[[:space:]]*//')
-    echo "${val:-0}"
+    local pattern="\"${field}\"[[:space:]]*:[[:space:]]*([0-9]+)"
+    if [[ "$state_json" =~ $pattern ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    else
+        echo "0"
+    fi
 }
 
 # --- Effective session_id: config.env → state.json ---
@@ -197,26 +221,30 @@ task_label_for_state() {
 # --- Write state.json ---
 write_state() {
     local json="$1"
-    local state_dir
-    state_dir="$(get_state_dir)"
-    echo "$json" > "$state_dir/state.json"
+    ensure_state_dir
+    echo "$json" > "$STATE_DIR/state.json"
 }
 
 # --- Write STATUS.md from current state.json ---
 write_status() {
-    local state_dir
-    state_dir="$(get_state_dir)"
+    ensure_state_dir
+    local state_dir="$STATE_DIR"
+    local state_file="$state_dir/state.json"
     local status_file="$state_dir/STATUS.md"
+    local state_json=""
+
+    if [[ -f "$state_file" ]]; then
+        state_json="$(<"$state_file")"
+    fi
 
     local task phase iteration max_iter review_status
-    task="$(read_state_field "task_description")"
-    phase="$(read_state_field "phase")"
-    iteration="$(read_state_number "iteration")"
-    max_iter="$(read_state_number "max_iterations")"
-    review_status="$(read_state_field "last_review_status")"
+    task="$(read_state_field "task_description" "$state_json")"
+    phase="$(read_state_field "phase" "$state_json")"
+    iteration="$(read_state_number "iteration" "$state_json")"
+    max_iter="$(read_state_number "max_iterations" "$state_json")"
+    review_status="$(read_state_field "last_review_status" "$state_json")"
 
-    local branch
-    branch="$(get_branch_slug)"
+    local branch="${state_dir##*/}"
 
     {
         echo "# Active Codex Review"
@@ -234,9 +262,8 @@ write_status() {
 
 # --- Remove STATUS.md (review complete or full reset) ---
 remove_status() {
-    local state_dir
-    state_dir="$(get_state_dir)"
-    rm -f "$state_dir/STATUS.md"
+    ensure_state_dir
+    rm -f "$STATE_DIR/STATUS.md"
 }
 
 # --- Parse verdict file ---
@@ -255,10 +282,9 @@ parse_verdict_file() {
 
 # --- Archive previous session artifacts ---
 archive_previous_session() {
-    local state_dir
-    state_dir="$(get_state_dir)"
-    local review_root
-    review_root="$(get_review_root)"
+    ensure_state_dir
+    local state_dir="$STATE_DIR"
+    local review_root="${state_dir%/*}"
     local has_artifacts=false
 
     # Check if there's anything to archive
@@ -335,8 +361,7 @@ generate_archive_summary() {
     # Escape task_desc for JSON (replace " with \", newlines with \n)
     task_desc="$(echo "$task_desc" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')"
 
-    local branch
-    branch="$(get_branch_slug)"
+    local branch="${state_dir##*/}"
 
     cat > "$archive_dir/summary.json" <<SUMMARY_EOF
 {

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -77,9 +77,12 @@ Regression tests for state reads on the hot path. Covers:
 
 - `write_status` and the standalone readers reuse the `STATE_DIR` already
   resolved by the entry script;
+- state and config helpers can reuse one explicitly resolved review root;
 - `write_status` derives the branch from that same state directory;
 - string and numeric readers can parse one in-memory snapshot after the source
   file is no longer available;
+- archive summaries read their string fields through the same shared snapshot
+  parser;
 - missing values keep their existing empty-string / zero defaults.
 
 The test checks observable calls and output rather than a machine-dependent

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -12,6 +12,7 @@ Run everything from the repository root.
 test/
 ├── test-auto-approve-plan.sh   # unit tests for the auto-approve hook
 ├── test-integration.sh         # path-contract tests (hook ↔ state dir)
+├── test-state-cache.sh         # cached state path and batched STATUS.md reads
 ├── test-description-file.sh    # --description-file, per-attempt logs, saved request
 ├── test-severity-calibration.sh # severity scale, finding headings, verdict threshold
 ├── test-exec-flags.sh          # model and reasoning effort on every codex exec call
@@ -68,6 +69,26 @@ Run:
 
 ```sh
 sh plugins/codex-review/test/test-integration.sh
+```
+
+## test-state-cache.sh
+
+Regression tests for state reads on the hot path. Covers:
+
+- `write_status` and the standalone readers reuse the `STATE_DIR` already
+  resolved by the entry script;
+- `write_status` derives the branch from that same state directory;
+- string and numeric readers can parse one in-memory snapshot after the source
+  file is no longer available;
+- missing values keep their existing empty-string / zero defaults.
+
+The test checks observable calls and output rather than a machine-dependent
+timing threshold.
+
+Run:
+
+```sh
+sh plugins/codex-review/test/test-state-cache.sh
 ```
 
 ## test-description-file.sh

--- a/plugins/codex-review/test/test-state-cache.sh
+++ b/plugins/codex-review/test/test-state-cache.sh
@@ -99,5 +99,81 @@ assert_file_contains "STATUS.md keeps the phase" "$STATUS_FILE" "- Phase: code"
 assert_file_contains "STATUS.md keeps both iteration values" "$STATUS_FILE" "- Iteration: 3/5"
 assert_file_contains "STATUS.md keeps the verdict" "$STATUS_FILE" "- Last status: CHANGES_REQUESTED"
 
+printf '\nTest 2: path helpers reuse one resolved review root\n'
+REVIEW_ROOT="$TEST_ROOT/provided-review-root"
+mkdir -p "$REVIEW_ROOT"
+printf 'CODEX_MAX_ITERATIONS=9\n' > "$REVIEW_ROOT/config.env"
+
+root_values="$(bash -c '
+    set -euo pipefail
+    source "$1"
+
+    get_review_root() {
+        echo "get_review_root must not run when a root is provided" >&2
+        return 97
+    }
+    get_branch_slug() {
+        printf "%s\n" "cached-branch"
+    }
+
+    state_dir="$(get_state_dir "$2")"
+    load_config "$2"
+    printf "%s|%s" "$state_dir" "$CODEX_MAX_ITERATIONS"
+' _ "$COMMON" "$REVIEW_ROOT")" || {
+    fail "path helpers accept the already resolved review root" "$root_values"
+    root_values=""
+}
+
+assert_eq "state and config paths share one explicit root" \
+    "$REVIEW_ROOT/cached-branch|9" "$root_values"
+
+printf '\nTest 3: archive summary uses one shared state snapshot\n'
+ARCHIVE_STATE_DIR="$TEST_ROOT/archive-branch"
+ARCHIVE_DIR="$TEST_ROOT/archive-output"
+FIELD_LOG="$TEST_ROOT/archive-fields.log"
+mkdir -p "$ARCHIVE_STATE_DIR/notes" "$ARCHIVE_DIR"
+cp "$STATE_DIR/state.saved.json" "$ARCHIVE_STATE_DIR/state.json"
+touch "$ARCHIVE_STATE_DIR/notes/plan-review-1.md"
+touch "$ARCHIVE_STATE_DIR/notes/code-review-1.md"
+
+archive_fields="$(bash -c '
+    set -euo pipefail
+    source "$1"
+    expected_json="$(<"$2/state.json")"
+    archive_state_dir="$2"
+    field_log="$4"
+
+    read_state_field() {
+        if [[ $# -ne 2 || "$2" != "$expected_json" ]]; then
+            echo "archive reader must receive the same in-memory snapshot" >&2
+            return 98
+        fi
+        printf "%s\n" "$1" >> "$field_log"
+        rm -f "$archive_state_dir/state.json"
+        case "$1" in
+            task_description) echo "Archive task" ;;
+            session_id) echo "archive-session" ;;
+            last_review_status) echo "APPROVED" ;;
+            *) return 99 ;;
+        esac
+    }
+
+    generate_archive_summary "$2" "$3" "20260831T190000Z"
+    cat "$field_log"
+' _ "$COMMON" "$ARCHIVE_STATE_DIR" "$ARCHIVE_DIR" "$FIELD_LOG")" || {
+    fail "archive summary completes from one shared snapshot" "$archive_fields"
+    archive_fields=""
+}
+
+expected_archive_fields="$(printf 'task_description\nsession_id\nlast_review_status\n')"
+assert_eq "archive summary reads all strings through the shared parser" \
+    "$expected_archive_fields" "$archive_fields"
+assert_file_contains "archive summary keeps the task" \
+    "$ARCHIVE_DIR/summary.json" '"task_description": "Archive task'
+assert_file_contains "archive summary keeps the session" \
+    "$ARCHIVE_DIR/summary.json" '"session_id": "archive-session"'
+assert_file_contains "archive summary keeps the final status" \
+    "$ARCHIVE_DIR/summary.json" '"final_verdict": "APPROVED"'
+
 printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/plugins/codex-review/test/test-state-cache.sh
+++ b/plugins/codex-review/test/test-state-cache.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Regression tests for the cached state path and batched STATUS.md reads.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMMON="$SCRIPT_DIR/../skills/codex-review/scripts/common.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+    printf '  PASS: %s\n' "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf '  FAIL: %s\n' "$1"
+    [ -n "${2:-}" ] && printf '    %s\n' "$2"
+}
+
+assert_eq() {
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1" "expected: $2; actual: $3"
+    fi
+}
+
+assert_file_contains() {
+    if grep -qF -- "$3" "$2"; then
+        pass "$1"
+    else
+        fail "$1" "missing '$3' in $2"
+    fi
+}
+
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+STATE_DIR="$TEST_ROOT/cached-branch"
+mkdir -p "$STATE_DIR/notes"
+
+cat > "$STATE_DIR/state.json" <<'JSON'
+{
+  "session_id": "session-test",
+  "phase": "code",
+  "iteration": 3,
+  "max_iterations": 5,
+  "last_review_status": "CHANGES_REQUESTED",
+  "reviews_completed": 2,
+  "task_description": "Cached task"
+}
+JSON
+
+printf 'Test 1: STATUS.md reuses the resolved state context\n'
+values="$(bash -c '
+    set -euo pipefail
+    source "$1"
+    STATE_DIR="$2"
+
+    get_state_dir() {
+        echo "get_state_dir must not run after STATE_DIR is set" >&2
+        return 97
+    }
+    get_branch_slug() {
+        echo "get_branch_slug must not run while writing STATUS.md" >&2
+        return 98
+    }
+
+    write_status
+    direct_phase="$(read_state_field phase)"
+    direct_iteration="$(read_state_number iteration)"
+
+    snapshot="$(<"$STATE_DIR/state.json")"
+    mv "$STATE_DIR/state.json" "$STATE_DIR/state.saved.json"
+
+    snapshot_phase="$(read_state_field phase "$snapshot")"
+    snapshot_iteration="$(read_state_number iteration "$snapshot")"
+    missing_field="$(read_state_field missing "")"
+    missing_number="$(read_state_number missing "")"
+
+    printf "%s|%s|%s|%s|%s|%s" \
+        "$direct_phase" "$direct_iteration" \
+        "$snapshot_phase" "$snapshot_iteration" \
+        "$missing_field" "$missing_number"
+' _ "$COMMON" "$STATE_DIR")" || {
+    fail "cached state operations complete without resolving paths again" "$values"
+    values=""
+}
+
+assert_eq "direct readers reuse STATE_DIR and snapshot readers need no file" \
+    "code|3|code|3||0" "$values"
+
+STATUS_FILE="$STATE_DIR/STATUS.md"
+assert_file_contains "STATUS.md keeps the task" "$STATUS_FILE" "- Task: Cached task"
+assert_file_contains "STATUS.md derives the cached branch" "$STATUS_FILE" "- Branch: cached-branch"
+assert_file_contains "STATUS.md keeps the phase" "$STATUS_FILE" "- Phase: code"
+assert_file_contains "STATUS.md keeps both iteration values" "$STATUS_FILE" "- Iteration: 3/5"
+assert_file_contains "STATUS.md keeps the verdict" "$STATUS_FILE" "- Last status: CHANGES_REQUESTED"
+
+printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Что изменено

- `STATE_DIR` вычисляется один раз во входном скрипте и переиспользуется вспомогательными функциями;
- корень `.codex-review` также вычисляется один раз и явно передаётся загрузчику настроек и каталогу состояния;
- `write_status()` читает `state.json` один раз и передаёт снимок всем пяти чтениям полей;
- архивная сводка использует тот же общий разборщик и один снимок `state.json`;
- разбор строк и чисел выполняется встроенными средствами Bash без дополнительных `grep`, `head`, `sed` и `tr` на горячем пути;
- добавлены регрессионные проверки переиспользования путей и снимков;
- версия дополнения повышена до 1.4.2.

Отдельного долгоживущего кеша нет: пути переиспользуются только в пределах команды, а снимок — в пределах одной операции чтения.

## Результат

Локальный синтетический замер 50 вызовов `write_status()`:

- было: около 10,4 с;
- стало: около 0,25 с.

Это примерно 40-кратное ускорение. Тест не зависит от времени выполнения. Трассировка обоих входных скриптов подтверждает одно вычисление корня на команду.

## Проверка

- полный набор в Linux: 207 успешно, 0 ошибок;
- macOS: `test-auto-approve-plan.sh` — 48/48, `test-integration.sh` — 8/8, `test-state-cache.sh` — 11/11;
- проверка синтаксиса Bash/sh, JSON и `git diff --check`;
- ShellCheck: без предупреждений и ошибок;
- проверка структуры skill: успешно.

Сквозной тест с настоящими Codex/Claude не запускался: он явно включается через `CODEX_E2E=1`; обычный защитный запуск корректно вернул `SKIP`.

Closes #30