### PR TITLE
feat(telegraph-publisher): добавить статистику просмотров

### DIFF
--- a/plugins/telegraph-publisher/.claude-plugin/plugin.json
+++ b/plugins/telegraph-publisher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraph-publisher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Publish pages to Telegraph with media support: images, YouTube embeds, diagrams",
   "author": {
     "name": "Polyakov"

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/SKILL.md
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegraph-publisher
-description: "Publish pages to Telegraph with images, YouTube embeds, and diagrams. Supports auto-split for long articles. ALWAYS read SKILL.md before first use."
+description: "Publish and manage Telegraph pages with media, page-view statistics, and auto-split for long articles. ALWAYS read SKILL.md before first use."
 ---
 
 # telegraph-publisher
@@ -13,7 +13,7 @@ Best for: articles, research reports, documentation, illustrated content.
 - **DO NOT** pass raw markdown — convert to HTML fragment first (Telegraph API accepts Node JSON, the converter accepts HTML)
 - **DO NOT** pass content larger than 64KB without using auto-split — the script handles this automatically
 - **DO NOT** hardcode access tokens — use `config/.env`
-- **DO NOT** skip account setup — run `create_account.sh` first if no token exists
+- **DO NOT** skip account setup before publishing, editing, listing pages, or reading account details — page-view lookup is public
 
 ## Quick Start
 
@@ -23,6 +23,7 @@ Have token?   → Save to config/.env
 Publish page? → sh scripts/create_page.sh --title "Title" --html "<p>Content</p>"
 Edit page?    → sh scripts/edit_page.sh --path "Path-03-09" --title "Title" --html "<p>New</p>"
 List pages?   → sh scripts/list_pages.sh
+Page views?   → sh scripts/page_views.sh --path "Page-Title-03-09"
 Account info? → sh scripts/account_info.sh
 Permanent media? → sh scripts/github_upload.sh --file hero.webp --page-path page-path
 ```
@@ -46,7 +47,9 @@ Python scripts use stdlib only (`html.parser`, `json`, `sys`).
 
 ## Config
 
-Requires `TELEGRAPH_ACCESS_TOKEN` in `config/.env` or environment.
+`create_page.sh`, `edit_page.sh`, `list_pages.sh`, and `account_info.sh` require
+`TELEGRAPH_ACCESS_TOKEN` in `config/.env` or environment. Creating an account and
+reading public page-view statistics do not require an existing Telegraph token.
 
 For permanent media hosting, prefer a separate public GitHub repo + jsDelivr CDN.
 Reason: Telegraph's unofficial upload endpoint is unstable and should not be the default publishing path.
@@ -155,6 +158,24 @@ sh scripts/edit_page.sh --path "Page-Title-03-09" --title "Updated Title" --html
 sh scripts/list_pages.sh
 sh scripts/list_pages.sh --offset 0 --limit 20
 ```
+
+### page_views.sh
+Get total views or one calendar-period total for any public Telegraph page. No access token is required.
+```bash
+# All-time views
+sh scripts/page_views.sh --path "Page-Title-03-09"
+
+# Views for a year, month, day, or hour
+sh scripts/page_views.sh --path "Page-Title-03-09" --year 2026
+sh scripts/page_views.sh --path "Page-Title-03-09" --year 2026 --month 3
+sh scripts/page_views.sh --path "Page-Title-03-09" --year 2026 --month 3 --day 9
+sh scripts/page_views.sh --path "Page-Title-03-09" --year 2026 --month 3 --day 9 --hour 12
+```
+
+Period filters are hierarchical: month requires year, day requires month, and hour requires day.
+The command returns one view count for the selected period, not a time series.
+Telegraph does not document the timezone used for day and hour filters.
+Use hours 0-23; the live API rejects 24 despite listing it in the API documentation.
 
 ### github_upload.sh
 Upload local media to the GitHub assets repo and update page manifest:

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/page_views.sh
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/page_views.sh
@@ -120,6 +120,8 @@ fi
 
 check_prerequisites
 
+# Telegraph accepts path as a parameter or an endpoint suffix. Form encoding
+# keeps the user-provided public page path out of the request URL.
 set -- --data-urlencode "path=$PAGE_PATH"
 [ -z "$YEAR" ] || set -- "$@" --data-urlencode "year=$YEAR"
 [ -z "$MONTH" ] || set -- "$@" --data-urlencode "month=$MONTH"

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/page_views.sh
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/page_views.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# Get Telegraph page views, optionally for a calendar period
+# Usage: sh page_views.sh --path "Page-Title-03-09" [--year YYYY [--month M [--day D [--hour H]]]]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/common.sh"
+
+usage() {
+    echo "Usage: sh page_views.sh --path PATH [--year YYYY [--month M [--day D [--hour H]]]]"
+}
+
+require_value() {
+    _rv_option="$1"
+    _rv_value="${2-}"
+    case "$_rv_value" in
+        ""|--*)
+            echo "Error: $_rv_option requires a value." >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_integer_range() {
+    _vir_name="$1"
+    _vir_value="$2"
+    _vir_min="$3"
+    _vir_max="$4"
+
+    case "$_vir_value" in
+        *[!0-9]*)
+            echo "Error: $_vir_name must be an integer." >&2
+            exit 1
+            ;;
+    esac
+
+    # Avoid overflowing the shell's integer comparison on malformed input.
+    if [ "${#_vir_value}" -gt "${#_vir_max}" ]; then
+        echo "Error: $_vir_name must be between $_vir_min and $_vir_max." >&2
+        exit 1
+    fi
+
+    if [ "$_vir_value" -lt "$_vir_min" ] || [ "$_vir_value" -gt "$_vir_max" ]; then
+        echo "Error: $_vir_name must be between $_vir_min and $_vir_max." >&2
+        exit 1
+    fi
+}
+
+PAGE_PATH=""
+YEAR=""
+MONTH=""
+DAY=""
+HOUR=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --path)
+            require_value "$1" "${2-}"
+            PAGE_PATH="$2"
+            shift 2
+            ;;
+        --year)
+            require_value "$1" "${2-}"
+            YEAR="$2"
+            shift 2
+            ;;
+        --month)
+            require_value "$1" "${2-}"
+            MONTH="$2"
+            shift 2
+            ;;
+        --day)
+            require_value "$1" "${2-}"
+            DAY="$2"
+            shift 2
+            ;;
+        --hour)
+            require_value "$1" "${2-}"
+            HOUR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$PAGE_PATH" ]; then
+    echo "Error: --path is required." >&2
+    usage >&2
+    exit 1
+fi
+
+if [ -n "$MONTH" ] && [ -z "$YEAR" ]; then
+    echo "Error: --month requires --year." >&2
+    exit 1
+fi
+if [ -n "$DAY" ] && [ -z "$MONTH" ]; then
+    echo "Error: --day requires --month." >&2
+    exit 1
+fi
+if [ -n "$HOUR" ] && [ -z "$DAY" ]; then
+    echo "Error: --hour requires --day." >&2
+    exit 1
+fi
+
+[ -z "$YEAR" ] || validate_integer_range "year" "$YEAR" 2000 2100
+[ -z "$MONTH" ] || validate_integer_range "month" "$MONTH" 1 12
+[ -z "$DAY" ] || validate_integer_range "day" "$DAY" 1 31
+# Telegraph rejects 24 even though its API documentation lists 0-24.
+[ -z "$HOUR" ] || validate_integer_range "hour" "$HOUR" 0 23
+
+check_prerequisites
+
+set -- --data-urlencode "path=$PAGE_PATH"
+[ -z "$YEAR" ] || set -- "$@" --data-urlencode "year=$YEAR"
+[ -z "$MONTH" ] || set -- "$@" --data-urlencode "month=$MONTH"
+[ -z "$DAY" ] || set -- "$@" --data-urlencode "day=$DAY"
+[ -z "$HOUR" ] || set -- "$@" --data-urlencode "hour=$HOUR"
+
+_result=$(telegraph_post "getViews" "$@")
+printf '%s\n' "$_result" | python3 "$SCRIPT_DIR/parse_response.py" page_views

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/parse_response.py
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/parse_response.py
@@ -4,6 +4,7 @@
 Usage:
   echo '{"ok":true,"result":{...}}' | python3 parse_response.py account_info
   echo '{"ok":true,"result":{...}}' | python3 parse_response.py page_list
+  echo '{"ok":true,"result":{"views":42}}' | python3 parse_response.py page_views
 """
 
 import json
@@ -57,10 +58,16 @@ def parse_page_list(data):
     return '\n'.join(lines)
 
 
+def parse_page_views(data):
+    """Format getViews response."""
+    views = data.get('result', {}).get('views', 0)
+    return f'=== Page Views ===\nViews: {views}'
+
+
 def main():
     if len(sys.argv) < 2:
         print("Usage: parse_response.py <command>", file=sys.stderr)
-        print("Commands: account_info, page_list", file=sys.stderr)
+        print("Commands: account_info, page_list, page_views", file=sys.stderr)
         sys.exit(1)
 
     command = sys.argv[1]
@@ -70,6 +77,8 @@ def main():
         print(parse_account_info(data))
     elif command == 'page_list':
         print(parse_page_list(data))
+    elif command == 'page_views':
+        print(parse_page_views(data))
     else:
         # Fallback: pretty-print JSON
         print(json.dumps(data, indent=2, ensure_ascii=False))


### PR DESCRIPTION
## Что изменено

- добавлен `page_views.sh` для получения общего числа просмотров страницы;
- поддержаны необязательные фильтры `--year`, `--month`, `--day` и `--hour`;
- ответ `getViews` выводится в понятном виде через `parse_response.py`;
- добавлены примеры использования и уточнены требования к токену;
- версия плагина повышена до `1.1.0`.

Сценарий не требует токена: `getViews` — открытый метод Telegraph. Интеграция с `list_pages.sh` намеренно не добавлена, чтобы не выполнять отдельный запрос для каждой страницы.

## Проверка

- синтаксис `page_views.sh` проверен через `sh -n`;
- штатная проверка скилла: `Skill is valid!`;
- разбор ответа проверен на `{"ok":true,"result":{"views":42}}`;
- живые запросы без токена вернули данные для общего периода, года, месяца, дня и часа;
- час 23 принимается, час 24 и некорректные параметры отклоняются до сетевого запроса;
- `git diff --check origin/main...HEAD`.

Closes #71