### PR TITLE
feat(telegraph-publisher): настроить автора по умолчанию

### DIFF
--- a/plugins/telegraph-publisher/.claude-plugin/plugin.json
+++ b/plugins/telegraph-publisher/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraph-publisher",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Publish pages to Telegraph with media support: images, YouTube embeds, diagrams",
   "author": {
     "name": "Polyakov"

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/SKILL.md
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/SKILL.md
@@ -51,6 +51,18 @@ Python scripts use stdlib only (`html.parser`, `json`, `sys`).
 `TELEGRAPH_ACCESS_TOKEN` in `config/.env` or environment. Creating an account and
 reading public page-view statistics do not require an existing Telegraph token.
 
+Optional `TELEGRAPH_AUTHOR_NAME` and `TELEGRAPH_AUTHOR_URL` in `config/.env` or the
+environment provide author defaults. Explicit flags override each field,
+including empty strings, in `create_page.sh` and `edit_page.sh`. With neither
+a setting nor a flag, these scripts omit the field.
+These defaults also apply to edits: do not replace a page's different author
+unintentionally; pass the intended author explicitly. See
+[config/README.md](config/README.md#author-defaults) for precedence and account naming.
+
+If the user supplies an author as `[Channel Name](https://t.me/channel)`, pass
+`Channel Name` and `https://t.me/channel` as separate name and URL values.
+Scripts accept plain values, not Markdown author links.
+
 For permanent media hosting, prefer a separate public GitHub repo + jsDelivr CDN.
 Reason: Telegraph's unofficial upload endpoint is unstable and should not be the default publishing path.
 
@@ -108,6 +120,9 @@ sh scripts/create_account.sh --name "Author Name" [--author-url "https://..."]
 sh scripts/create_account.sh --revoke  # rotate token
 ```
 
+With a nonempty `TELEGRAPH_AUTHOR_NAME` configured, `--name` is optional. The public author
+name is kept in full; the private account label uses its first 32 Unicode characters.
+
 ### account_info.sh
 ```bash
 sh scripts/account_info.sh
@@ -135,8 +150,8 @@ sh scripts/create_page.sh --title "Article" --html-file a.html --author-name "Na
 | `--html` | one of three | Inline HTML string |
 | `--html-file` | one of three | Path to HTML file |
 | `--content-file` | one of three | Path to Node JSON file |
-| `--author-name` | no | Author name (0-128 chars) |
-| `--author-url` | no | Author profile URL |
+| `--author-name` | no | Author name (0-128 chars); overrides configured default |
+| `--author-url` | no | Author profile URL; overrides configured default |
 
 **Auto-split**: If content exceeds 60KB, automatically splits into multiple pages with an index page linking to parts.
 
@@ -150,8 +165,8 @@ sh scripts/edit_page.sh --path "Page-Title-03-09" --title "Updated Title" --html
 | `--path` | yes | Page path (from URL or create output) |
 | `--title` | yes | Page title |
 | `--html` / `--html-file` / `--content-file` | yes | New content |
-| `--author-name` | no | Author name |
-| `--author-url` | no | Author URL |
+| `--author-name` | no | Author name; overrides configured default |
+| `--author-url` | no | Author URL; overrides configured default |
 
 ### list_pages.sh
 ```bash

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/config/.env.example
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/config/.env.example
@@ -2,6 +2,11 @@
 # Get one by running: sh scripts/create_account.sh --name "YourName"
 TELEGRAPH_ACCESS_TOKEN=your_token_here
 
+# Optional author defaults for creating/editing pages and creating an account.
+# Leave commented out to omit these fields. Account creation needs a nonempty name.
+# TELEGRAPH_AUTHOR_NAME="Your Name"
+# TELEGRAPH_AUTHOR_URL="https://t.me/your_channel"
+
 # GitHub-backed permanent media hosting (recommended)
 # Public repo in owner/repo format, for example: yourname/telegraph-assets
 GITHUB_TOKEN=your_github_token_here

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/config/README.md
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/config/README.md
@@ -18,11 +18,41 @@
 
 ## Access Token
 
-The `TELEGRAPH_ACCESS_TOKEN` is required for all operations except reading public pages.
+The `TELEGRAPH_ACCESS_TOKEN` is required for creating, editing, and listing pages,
+reading account details, and rotating the token. Creating an account and reading
+public page views do not require an existing token.
 
 You can set it in two ways:
 - **File**: `config/.env` (recommended)
 - **Environment variable**: `export TELEGRAPH_ACCESS_TOKEN=...`
+
+## Author Defaults
+
+Set optional author fields in `config/.env` or the environment:
+
+```bash
+TELEGRAPH_AUTHOR_NAME="Поляков считает | Про ИИ, рекламу и аналитику данных"
+TELEGRAPH_AUTHOR_URL="https://t.me/polyakov_schitaet"
+```
+
+`create_page.sh` and `edit_page.sh` use these values when the corresponding
+`--author-name` or `--author-url` flag is absent. Each field is independent:
+overriding the name does not discard the configured URL. Split articles use
+the same author for every part and the index page.
+
+Priority: explicit flag, then a value declared in `config/.env`, then environment.
+An explicit empty value is sent as an empty API field, not replaced by a default.
+If a field is neither configured nor passed, it is omitted from the request.
+
+**Editing:** configured defaults are sent on edits too, so they can replace a
+page's existing author. For a page with a different author, pass the intended
+name and URL explicitly instead of using these defaults.
+
+`create_account.sh` also uses these defaults: `--name` and `--author-url` override
+them, and `--name` may be omitted when a nonempty default name is configured.
+The full name becomes the public `author_name` (up to 128 characters). Its first
+32 Unicode characters become the private account label, `short_name`, to fit
+Telegraph's smaller limit. `--revoke` does not change author information.
 
 ## GitHub Media Hosting (recommended)
 

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/create_account.sh
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/create_account.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Create or manage a Telegraph account
 # Usage:
+#   sh create_account.sh   # Use TELEGRAPH_AUTHOR_NAME/URL from config or environment
 #   sh create_account.sh --name "Author Name" [--author-url "https://..."]
 #   sh create_account.sh --revoke   # Rotate token (requires existing token in config)
 
@@ -8,17 +9,19 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/common.sh"
+load_config_optional
 
 # Parse arguments
-SHORT_NAME=""
-AUTHOR_NAME=""
-AUTHOR_URL=""
+SHORT_NAME="${TELEGRAPH_AUTHOR_NAME-}"
+AUTHOR_NAME="$SHORT_NAME"
+AUTHOR_URL="${TELEGRAPH_AUTHOR_URL-}"
+AUTHOR_URL_SET="${TELEGRAPH_AUTHOR_URL+x}"
 REVOKE=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --name)       SHORT_NAME="$2"; AUTHOR_NAME="$2"; shift 2 ;;
-        --author-url) AUTHOR_URL="$2"; shift 2 ;;
+        --author-url) AUTHOR_URL="$2"; AUTHOR_URL_SET=1; shift 2 ;;
         --revoke)     REVOKE="1"; shift ;;
         *)            shift ;;
     esac
@@ -48,16 +51,22 @@ fi
 
 if [ -z "$SHORT_NAME" ]; then
     echo "Usage: sh create_account.sh --name \"Your Name\" [--author-url URL]" >&2
+    echo "       Or set TELEGRAPH_AUTHOR_NAME in config/.env or environment." >&2
     echo "       sh create_account.sh --revoke" >&2
     exit 1
 fi
+
+# The private account label is limited to 32 characters; the public author
+# name may be longer. Slice Unicode characters, not UTF-8 bytes.
+check_python3
+SHORT_NAME=$(python3 -c 'import sys; print(sys.argv[1][:32], end="")' "$SHORT_NAME")
 
 # Build curl args as proper argv
 set -- --data-urlencode "short_name=$SHORT_NAME"
 if [ -n "$AUTHOR_NAME" ]; then
     set -- "$@" --data-urlencode "author_name=$AUTHOR_NAME"
 fi
-if [ -n "$AUTHOR_URL" ]; then
+if [ -n "$AUTHOR_URL_SET" ]; then
     set -- "$@" --data-urlencode "author_url=$AUTHOR_URL"
 fi
 

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/create_page.sh
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/create_page.sh
@@ -17,8 +17,10 @@ TITLE=""
 CONTENT_FILE=""
 HTML_FILE=""
 HTML_INLINE=""
-AUTHOR_NAME=""
-AUTHOR_URL=""
+AUTHOR_NAME="${TELEGRAPH_AUTHOR_NAME-}"
+AUTHOR_URL="${TELEGRAPH_AUTHOR_URL-}"
+AUTHOR_NAME_SET="${TELEGRAPH_AUTHOR_NAME+x}"
+AUTHOR_URL_SET="${TELEGRAPH_AUTHOR_URL+x}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -26,8 +28,8 @@ while [ $# -gt 0 ]; do
         --content-file) CONTENT_FILE="$2"; shift 2 ;;
         --html-file)    HTML_FILE="$2"; shift 2 ;;
         --html)         HTML_INLINE="$2"; shift 2 ;;
-        --author-name)  AUTHOR_NAME="$2"; shift 2 ;;
-        --author-url)   AUTHOR_URL="$2"; shift 2 ;;
+        --author-name)  AUTHOR_NAME="$2"; AUTHOR_NAME_SET=1; shift 2 ;;
+        --author-url)   AUTHOR_URL="$2"; AUTHOR_URL_SET=1; shift 2 ;;
         *)              shift ;;
     esac
 done
@@ -57,19 +59,6 @@ else
     echo "Error: Provide --content-file, --html-file, or --html" >&2
     exit 1
 fi
-
-# --------------- Helper: build common author args ---------------
-# Appends --data-urlencode author_name/author_url to positional params
-# Call: _build_author_args; then use "$@"
-_build_author_args() {
-    if [ -n "$AUTHOR_NAME" ]; then
-        set -- "$@" --data-urlencode "author_name=$AUTHOR_NAME"
-    fi
-    if [ -n "$AUTHOR_URL" ]; then
-        set -- "$@" --data-urlencode "author_url=$AUTHOR_URL"
-    fi
-    # Return args via stdout, one per line — caller collects
-}
 
 # --------------- Check size and split if needed ---------------
 
@@ -110,10 +99,10 @@ if [ "$_size" -gt 61440 ]; then
         set -- "$@" --data-urlencode "title=$_part_title"
         set -- "$@" --data-urlencode "content=$_part_content"
         set -- "$@" -d "return_content=false"
-        if [ -n "$AUTHOR_NAME" ]; then
+        if [ -n "$AUTHOR_NAME_SET" ]; then
             set -- "$@" --data-urlencode "author_name=$AUTHOR_NAME"
         fi
-        if [ -n "$AUTHOR_URL" ]; then
+        if [ -n "$AUTHOR_URL_SET" ]; then
             set -- "$@" --data-urlencode "author_url=$AUTHOR_URL"
         fi
 
@@ -147,10 +136,10 @@ print(json.dumps(nodes, ensure_ascii=False))
     set -- "$@" --data-urlencode "title=$TITLE"
     set -- "$@" --data-urlencode "content=$_index_content"
     set -- "$@" -d "return_content=false"
-    if [ -n "$AUTHOR_NAME" ]; then
+    if [ -n "$AUTHOR_NAME_SET" ]; then
         set -- "$@" --data-urlencode "author_name=$AUTHOR_NAME"
     fi
-    if [ -n "$AUTHOR_URL" ]; then
+    if [ -n "$AUTHOR_URL_SET" ]; then
         set -- "$@" --data-urlencode "author_url=$AUTHOR_URL"
     fi
 
@@ -176,10 +165,10 @@ set -- "$@" --data-urlencode "title=$TITLE"
 set -- "$@" --data-urlencode "content=$_content"
 set -- "$@" -d "return_content=false"
 
-if [ -n "$AUTHOR_NAME" ]; then
+if [ -n "$AUTHOR_NAME_SET" ]; then
     set -- "$@" --data-urlencode "author_name=$AUTHOR_NAME"
 fi
-if [ -n "$AUTHOR_URL" ]; then
+if [ -n "$AUTHOR_URL_SET" ]; then
     set -- "$@" --data-urlencode "author_url=$AUTHOR_URL"
 fi
 

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/edit_page.sh
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/edit_page.sh
@@ -17,8 +17,10 @@ TITLE=""
 CONTENT_FILE=""
 HTML_FILE=""
 HTML_INLINE=""
-AUTHOR_NAME=""
-AUTHOR_URL=""
+AUTHOR_NAME="${TELEGRAPH_AUTHOR_NAME-}"
+AUTHOR_URL="${TELEGRAPH_AUTHOR_URL-}"
+AUTHOR_NAME_SET="${TELEGRAPH_AUTHOR_NAME+x}"
+AUTHOR_URL_SET="${TELEGRAPH_AUTHOR_URL+x}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -27,8 +29,8 @@ while [ $# -gt 0 ]; do
         --content-file) CONTENT_FILE="$2"; shift 2 ;;
         --html-file)    HTML_FILE="$2"; shift 2 ;;
         --html)         HTML_INLINE="$2"; shift 2 ;;
-        --author-name)  AUTHOR_NAME="$2"; shift 2 ;;
-        --author-url)   AUTHOR_URL="$2"; shift 2 ;;
+        --author-name)  AUTHOR_NAME="$2"; AUTHOR_NAME_SET=1; shift 2 ;;
+        --author-url)   AUTHOR_URL="$2"; AUTHOR_URL_SET=1; shift 2 ;;
         *)              shift ;;
     esac
 done
@@ -64,10 +66,10 @@ set -- "$@" --data-urlencode "title=$TITLE"
 set -- "$@" --data-urlencode "content=$_content"
 set -- "$@" -d "return_content=false"
 
-if [ -n "$AUTHOR_NAME" ]; then
+if [ -n "$AUTHOR_NAME_SET" ]; then
     set -- "$@" --data-urlencode "author_name=$AUTHOR_NAME"
 fi
-if [ -n "$AUTHOR_URL" ]; then
+if [ -n "$AUTHOR_URL_SET" ]; then
     set -- "$@" --data-urlencode "author_url=$AUTHOR_URL"
 fi
 

--- a/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/tests/test_author_defaults.sh
+++ b/plugins/telegraph-publisher/skills/telegraph-publisher/scripts/tests/test_author_defaults.sh
@@ -1,0 +1,225 @@
+#!/bin/sh
+# Автор из config/env, приоритет флагов и пустые значения. Сеть не используется.
+# Запуск: sh scripts/tests/test_author_defaults.sh
+
+set -eu
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+TEST_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tph_author_test.XXXXXX")
+trap 'rm -rf "$TEST_TMP_DIR"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+TEST_SCRIPTS="$TEST_TMP_DIR/skill/scripts"
+TEST_CONFIG="$TEST_TMP_DIR/skill/config/.env"
+mkdir -p "$TEST_SCRIPTS" "$TEST_TMP_DIR/skill/config" "$TEST_TMP_DIR/bin" "$TEST_TMP_DIR/tmp"
+for script in common.sh create_page.sh edit_page.sh create_account.sh content_converter.py; do
+    cp "$SCRIPTS_DIR/$script" "$TEST_SCRIPTS/$script"
+done
+
+# Копия скриптов использует только наш .env, а curl лишь записывает argv.
+TPH_TEST_PYTHON="$(python3 -c 'import sys; print(sys.executable)')"
+export TPH_TEST_PYTHON
+cat > "$TEST_TMP_DIR/bin/curl" <<'CURL'
+#!/bin/sh
+exec "$TPH_TEST_PYTHON" - "$@" <<'PY'
+import json
+import os
+import sys
+
+with open(os.environ['TPH_TEST_CURL_LOG'], 'a', encoding='utf-8') as log:
+    log.write(json.dumps(sys.argv[1:], ensure_ascii=False) + '\n')
+print(json.dumps({'ok': True, 'result': {
+    'url': 'https://telegra.ph/Test-01-01',
+    'path': 'Test-01-01',
+    'short_name': 'Test',
+    'access_token': 'new-test-token',
+    'auth_url': 'https://example.invalid/auth',
+}}))
+PY
+CURL
+chmod +x "$TEST_TMP_DIR/bin/curl"
+
+PATH="$TEST_TMP_DIR/bin:$PATH"
+TMPDIR="$TEST_TMP_DIR/tmp"
+PYTHONDONTWRITEBYTECODE=1
+export PATH TMPDIR PYTHONDONTWRITEBYTECODE
+unset TELEGRAPH_ACCESS_TOKEN TELEGRAPH_AUTHOR_NAME TELEGRAPH_AUTHOR_URL
+
+ABSENT='__ABSENT__'
+AUTHOR_DEFAULT='Поляков считает | Про ИИ, рекламу и аналитику данных'
+URL_DEFAULT='https://t.me/polyakov_schitaet'
+
+# Все значения здесь — фиксированные тестовые строки без одинарных кавычек.
+write_config() {
+    {
+        if [ "$1" != "$ABSENT" ]; then
+            printf "TELEGRAPH_ACCESS_TOKEN='%s'\n" "$1"
+        fi
+        if [ "$2" != "$ABSENT" ]; then
+            printf "TELEGRAPH_AUTHOR_NAME='%s'\n" "$2"
+        fi
+        if [ "$3" != "$ABSENT" ]; then
+            printf "TELEGRAPH_AUTHOR_URL='%s'\n" "$3"
+        fi
+    } > "$TEST_CONFIG"
+}
+
+run_case() {
+    TEST_CASE="$1"
+    _case_expected="$2"
+    _case_script="$3"
+    shift 3
+    TPH_TEST_CURL_LOG="$TEST_TMP_DIR/$TEST_CASE.requests.jsonl"
+    export TPH_TEST_CURL_LOG
+    : > "$TPH_TEST_CURL_LOG"
+    _case_status=0
+    (cd "$TEST_TMP_DIR" && sh "$TEST_SCRIPTS/$_case_script" "$@") \
+        > "$TEST_TMP_DIR/$TEST_CASE.out" 2> "$TEST_TMP_DIR/$TEST_CASE.err" || _case_status=$?
+
+    if [ "$_case_expected" = ok ] && [ "$_case_status" -ne 0 ]; then
+        printf '%s: неожиданный код выхода %s\n' "$TEST_CASE" "$_case_status" >&2
+        cat "$TEST_TMP_DIR/$TEST_CASE.err" >&2
+        exit 1
+    fi
+    if [ "$_case_expected" = fail ]; then
+        if [ "$_case_status" -eq 0 ]; then
+            printf '%s: ожидалась ошибка\n' "$TEST_CASE" >&2
+            exit 1
+        fi
+        if [ -s "$TPH_TEST_CURL_LOG" ]; then
+            printf '%s: curl не должен вызываться при ошибке\n' "$TEST_CASE" >&2
+            exit 1
+        fi
+    fi
+}
+
+# Ожидания: key=value — точное значение, !key — поле отсутствует.
+assert_requests() {
+    python3 - "$TPH_TEST_CURL_LOG" "$TEST_CASE" "$@" <<'PY'
+import json
+import sys
+
+log_path, label, count, method, *expected = sys.argv[1:]
+with open(log_path, encoding='utf-8') as log:
+    requests = [json.loads(line) for line in log]
+
+def check(condition, message):
+    if not condition:
+        raise SystemExit(f'{label}: {message}')
+
+check(len(requests) == int(count), f'ожидалось {count} запросов, получено {len(requests)}')
+for number, argv in enumerate(requests, 1):
+    check(argv[-1] == f'https://api.telegra.ph/{method}', f'запрос {number}: неверный метод')
+    fields = {}
+    for index, arg in enumerate(argv):
+        if arg not in ('-d', '--data-urlencode'):
+            continue
+        key, value = argv[index + 1].split('=', 1)
+        check(key not in fields, f'запрос {number}: поле {key} передано дважды')
+        fields[key] = value
+    for item in expected:
+        if item.startswith('!'):
+            check(item[1:] not in fields, f'запрос {number}: лишнее поле {item[1:]}')
+        else:
+            key, value = item.split('=', 1)
+            check(key in fields, f'запрос {number}: нет поля {key}')
+            check(fields[key] == value, f'запрос {number}: {key}={fields[key]!r}, ожидалось {value!r}')
+PY
+}
+
+# Без настроек автора прежнее поведение сохраняется: поля не отправляются.
+write_config test-token "$ABSENT" "$ABSENT"
+run_case create_unset ok create_page.sh --title Test --html '<p>Hello</p>'
+assert_requests 1 createPage '!author_name' '!author_url'
+run_case edit_unset ok edit_page.sh --path Test-01-01 --title Test --html '<p>Hello</p>'
+assert_requests 1 editPage/Test-01-01 '!author_name' '!author_url'
+
+# Объявленные поля .env выше окружения — это существующий порядок load_config.
+TELEGRAPH_AUTHOR_NAME='Автор из окружения'
+TELEGRAPH_AUTHOR_URL='https://example.invalid/environment'
+export TELEGRAPH_AUTHOR_NAME TELEGRAPH_AUTHOR_URL
+write_config test-token "$AUTHOR_DEFAULT" "$URL_DEFAULT"
+run_case create_config ok create_page.sh --title Test --html '<p>Hello</p>'
+assert_requests 1 createPage "author_name=$AUTHOR_DEFAULT" "author_url=$URL_DEFAULT"
+unset TELEGRAPH_AUTHOR_NAME TELEGRAPH_AUTHOR_URL
+
+# Без .env значения берутся из окружения.
+rm -f "$TEST_CONFIG"
+TELEGRAPH_ACCESS_TOKEN=test-token
+TELEGRAPH_AUTHOR_NAME="$AUTHOR_DEFAULT"
+TELEGRAPH_AUTHOR_URL="$URL_DEFAULT"
+export TELEGRAPH_ACCESS_TOKEN TELEGRAPH_AUTHOR_NAME TELEGRAPH_AUTHOR_URL
+run_case edit_environment ok edit_page.sh --path Test-01-01 --title Test --html '<p>Hello</p>'
+assert_requests 1 editPage/Test-01-01 "author_name=$AUTHOR_DEFAULT" "author_url=$URL_DEFAULT"
+unset TELEGRAPH_ACCESS_TOKEN TELEGRAPH_AUTHOR_NAME TELEGRAPH_AUTHOR_URL
+
+write_config test-token "$AUTHOR_DEFAULT" "$URL_DEFAULT"
+run_case create_name_override ok create_page.sh --title Test --html '<p>Hello</p>' --author-name 'Явный автор'
+assert_requests 1 createPage 'author_name=Явный автор' "author_url=$URL_DEFAULT"
+run_case edit_url_override ok edit_page.sh --path Test-01-01 --title Test --html '<p>Hello</p>' --author-url 'https://example.invalid/explicit'
+assert_requests 1 editPage/Test-01-01 "author_name=$AUTHOR_DEFAULT" 'author_url=https://example.invalid/explicit'
+
+# Пустое значение — явная передача пустого поля, а не возврат к default.
+run_case create_empty ok create_page.sh --title Test --html '<p>Hello</p>' --author-name '' --author-url ''
+assert_requests 1 createPage 'author_name=' 'author_url='
+run_case edit_empty ok edit_page.sh --path Test-01-01 --title Test --html '<p>Hello</p>' --author-name '' --author-url ''
+assert_requests 1 editPage/Test-01-01 'author_name=' 'author_url='
+
+# Объявленное пустое поле .env отличается от необъявленного.
+write_config test-token '' ''
+run_case create_empty_config ok create_page.sh --title Test --html '<p>Hello</p>'
+assert_requests 1 createPage 'author_name=' 'author_url='
+write_config test-token "$AUTHOR_DEFAULT" "$ABSENT"
+run_case edit_name_only ok edit_page.sh --path Test-01-01 --title Test --html '<p>Hello</p>'
+assert_requests 1 editPage/Test-01-01 "author_name=$AUTHOR_DEFAULT" '!author_url'
+write_config test-token "$AUTHOR_DEFAULT" "$URL_DEFAULT"
+
+# Несколько небольших узлов: суммарно >60 КБ, каждый отдельно меньше лимита.
+python3 - "$TEST_TMP_DIR/large.json" <<'PY'
+import json
+import sys
+
+nodes = [{'tag': 'p', 'children': ['x' * 11000]} for _ in range(6)]
+with open(sys.argv[1], 'w', encoding='utf-8') as target:
+    json.dump(nodes, target)
+PY
+run_case split_config ok create_page.sh --title Test --content-file "$TEST_TMP_DIR/large.json"
+assert_requests 3 createPage "author_name=$AUTHOR_DEFAULT" "author_url=$URL_DEFAULT"
+grep -q '^Parts:     2$' "$TEST_TMP_DIR/split_config.out"
+run_case split_empty ok create_page.sh --title Test --content-file "$TEST_TMP_DIR/large.json" --author-name '' --author-url ''
+assert_requests 3 createPage 'author_name=' 'author_url='
+grep -q '^Parts:     2$' "$TEST_TMP_DIR/split_empty.out"
+
+# Создание аккаунта не требует токена. Публичное имя не обрезается.
+write_config "$ABSENT" "$AUTHOR_DEFAULT" "$URL_DEFAULT"
+run_case account_config ok create_account.sh
+assert_requests 1 createAccount \
+    'short_name=Поляков считает | Про ИИ, реклам' \
+    "author_name=$AUTHOR_DEFAULT" "author_url=$URL_DEFAULT" '!access_token'
+
+run_case account_override ok create_account.sh --name 'Явный автор' --author-url ''
+assert_requests 1 createAccount 'short_name=Явный автор' 'author_name=Явный автор' 'author_url=' '!access_token'
+run_case account_empty_name fail create_account.sh --name ''
+write_config "$ABSENT" "$ABSENT" "$ABSENT"
+run_case account_missing_name fail create_account.sh
+
+# Отзыв токена использует только токен; настройки автора ему не нужны.
+# В его PATH нет python3: новая обрезка имени не должна затрагивать --revoke.
+NO_PYTHON_BIN="$TEST_TMP_DIR/no-python-bin"
+mkdir -p "$NO_PYTHON_BIN"
+for command_name in sh dirname mkdir grep head sed cat rm; do
+    ln -s "$(command -v "$command_name")" "$NO_PYTHON_BIN/$command_name"
+done
+ln -s "$TEST_TMP_DIR/bin/curl" "$NO_PYTHON_BIN/curl"
+write_config test-token "$AUTHOR_DEFAULT" "$URL_DEFAULT"
+TEST_ORIGINAL_PATH="$PATH"
+PATH="$NO_PYTHON_BIN"
+run_case revoke ok create_account.sh --revoke
+PATH="$TEST_ORIGINAL_PATH"
+assert_requests 1 revokeAccessToken 'access_token=test-token' '!short_name' '!author_name' '!author_url'
+write_config "$ABSENT" "$AUTHOR_DEFAULT" "$URL_DEFAULT"
+run_case revoke_without_token fail create_account.sh --revoke
+
+echo PASS


### PR DESCRIPTION
## Что изменено

- `TELEGRAPH_AUTHOR_NAME` и `TELEGRAPH_AUTHOR_URL` из конфигурации или окружения используются в `create_page.sh`, `edit_page.sh` и `create_account.sh`;
- явные флаги переопределяют каждое поле отдельно, включая пустые значения для страниц;
- сведения об авторе одинаково передаются всем частям длинной статьи и оглавлению;
- создание учётной записи не требует существующего токена; полное публичное имя сохраняется, внутренний `short_name` ограничивается первыми 32 Unicode-символами;
- обновлены пример конфигурации и инструкции, версия плагина — `1.2.0`;
- удалён неиспользуемый помощник сборки параметров автора.

`common.sh` не изменён: он уже загружает любые переменные из `.env`.

## Границы решения

- Настройки действуют и при редактировании, как предложено в №72. В инструкциях явно отмечено, что это может заменить прежнюю подпись страницы.
- Markdown-ссылка на автора разбирается агентом по инструкции в `SKILL.md` на два обычных поля. Дополнительный разбор Markdown в скриптах не добавлен.
- Настоящий `config/.env` не изменялся, страницы и учётные записи для тестов не создавались.

## Проверка

- `sh plugins/telegraph-publisher/skills/telegraph-publisher/scripts/tests/test_author_defaults.sh` — `PASS`;
- проверены отсутствие полей, настройки из файла и окружения, приоритет и пустые значения флагов, все запросы разделённой статьи, длинное кириллическое имя и отзыв токена;
- тест работает с временной копией сценариев, отдельной конфигурацией и подставным `curl`, без сети;
- `sh -n` для изменённых сценариев и теста;
- штатная проверка скилла — `Skill is valid!`;
- `git diff --cached --check`;
- независимая проверка кода — без замечаний.

Refs #72