### PR TITLE
fix(codex-review): make `codex-state.sh set` write what it reports

### DIFF
--- a/plugins/codex-review/.claude-plugin/plugin.json
+++ b/plugins/codex-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review",
   "description": "Cross-agent review workflow: Claude implements, Codex reviews",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "Polyakov"
   },

--- a/plugins/codex-review/skills/codex-review/README.md
+++ b/plugins/codex-review/skills/codex-review/README.md
@@ -170,7 +170,14 @@ bash scripts/codex-state.sh reset         # Сброс итераций
 bash scripts/codex-state.sh reset --full  # Полный сброс
 bash scripts/codex-state.sh set session_id <value>  # Ручная установка
 bash scripts/codex-state.sh set phase implementing  # Обновить фазу
+bash scripts/codex-state.sh set iteration 2        # Откатить счётчик кругов
 ```
+
+Записываемые поля: `session_id`, `phase`, `iteration`, `max_iterations`,
+`reviews_completed`, `last_review_status`, `last_review_timestamp`,
+`task_description`. Неизвестное имя поля, нецелое значение счётчика и значение
+с кавычкой, обратным слэшем, переводом строки или табуляцией — ошибка с кодом
+возврата 1, состояние не меняется.
 
 ## Структура .codex-review/
 

--- a/plugins/codex-review/skills/codex-review/SKILL.md
+++ b/plugins/codex-review/skills/codex-review/SKILL.md
@@ -136,7 +136,14 @@ bash scripts/codex-state.sh reset --full      # Полный сброс
 bash scripts/codex-state.sh get session_id    # Получить поле
 bash scripts/codex-state.sh set session_id <val>  # Установить вручную
 bash scripts/codex-state.sh set phase implementing  # Обновить фазу
+bash scripts/codex-state.sh set iteration 2       # Откатить счётчик кругов
 ```
+
+`set` принимает поля `session_id`, `phase`, `iteration`, `max_iterations`,
+`reviews_completed`, `last_review_status`, `last_review_timestamp`,
+`task_description`. Неизвестное имя поля, нецелое значение счётчика и значение
+с кавычкой, обратным слэшем, переводом строки или табуляцией — ошибка с кодом
+возврата 1, состояние не меняется.
 
 Для чтения файлов ревью (notes, STATUS.md и пр.) используй `codex-state.sh dir` — он вернёт абсолютный путь к каталогу текущей ветки.
 

--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -169,12 +169,19 @@ fi
 # --- Load config & state ---
 REVIEW_ROOT="$(get_review_root)"
 load_config "$REVIEW_ROOT"
+
+# The limit is checked as soon as both of its sources are known and before
+# anything else runs — the codex probe included: it reaches state.json as a JSON
+# number, and a value the file cannot hold would otherwise surface only at the
+# write that follows the codex call, with the session already opened.
+MAX_ITERATIONS="$(state_counter_value "${MAX_ITER:-$CODEX_MAX_ITERATIONS}" "the iteration limit" \
+    'Pass --max-iter <N>, or fix CODEX_MAX_ITERATIONS in .codex-review/config.env.')" || exit 1
+
 check_codex_installed
 
 STATE_DIR="$(get_state_dir "$REVIEW_ROOT")"
 unset REVIEW_ROOT
 
-MAX_ITERATIONS="${MAX_ITER:-$CODEX_MAX_ITERATIONS}"
 SESSION_ID="$(get_effective_session_id)"
 
 # --- Build codex exec flags (as arrays to avoid word splitting) ---
@@ -355,16 +362,15 @@ update_state() {
     local task_desc
     task_desc="$(read_state_field "task_description")"
 
-    write_state "{
-  \"session_id\": \"$SESSION_ID\",
-  \"phase\": \"$phase\",
-  \"iteration\": $iteration,
-  \"max_iterations\": $MAX_ITERATIONS,
-  \"last_review_status\": \"$status\",
-  \"last_review_timestamp\": \"$timestamp\",
-  \"reviews_completed\": $reviews_completed,
-  \"task_description\": \"$task_desc\"
-}"
+    write_state_fields \
+        session_id="$SESSION_ID" \
+        phase="$phase" \
+        iteration="$iteration" \
+        max_iterations="$MAX_ITERATIONS" \
+        last_review_status="$status" \
+        last_review_timestamp="$timestamp" \
+        reviews_completed="$reviews_completed" \
+        task_description="$task_desc"
 }
 
 # --- Format output ---
@@ -641,16 +647,15 @@ cmd_init() {
     # Extract session_id
     SESSION_ID="$(resolve_new_session_id "$marker" "$log_file")"
 
-    write_state "{
-  \"session_id\": \"$SESSION_ID\",
-  \"phase\": \"initialized\",
-  \"iteration\": 0,
-  \"max_iterations\": $MAX_ITERATIONS,
-  \"last_review_status\": \"\",
-  \"last_review_timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",
-  \"reviews_completed\": 0,
-  \"task_description\": \"$TASK_LABEL_JSON\"
-}"
+    write_state_fields \
+        session_id="$SESSION_ID" \
+        phase="initialized" \
+        iteration=0 \
+        max_iterations="$MAX_ITERATIONS" \
+        last_review_status="" \
+        last_review_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        reviews_completed=0 \
+        task_description="$TASK_LABEL_JSON"
 
     write_status
     echo "Session created: $SESSION_ID"
@@ -681,16 +686,15 @@ cmd_review() {
     if [[ -n "$previous_phase" && "$previous_phase" != "$phase" ]]; then
         local task_desc
         task_desc="$(read_state_field "task_description")"
-        write_state "{
-  \"session_id\": \"$SESSION_ID\",
-  \"phase\": \"$previous_phase\",
-  \"iteration\": 0,
-  \"max_iterations\": $MAX_ITERATIONS,
-  \"last_review_status\": \"\",
-  \"last_review_timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",
-  \"reviews_completed\": 0,
-  \"task_description\": \"$task_desc\"
-}"
+        write_state_fields \
+            session_id="$SESSION_ID" \
+            phase="$previous_phase" \
+            iteration=0 \
+            max_iterations="$MAX_ITERATIONS" \
+            last_review_status="" \
+            last_review_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+            reviews_completed=0 \
+            task_description="$task_desc"
         echo "Phase changed ($previous_phase → $phase), iteration counter reset." >&2
     fi
 

--- a/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
@@ -20,7 +20,15 @@ cmd_show() {
         # Replace session_id in output with effective value (config.env takes priority)
         sed "s|\"session_id\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"session_id\": \"$effective_sid\"|" "$STATE_FILE"
     else
-        echo "{\"session_id\":\"$effective_sid\",\"phase\":\"\",\"iteration\":0,\"max_iterations\":3,\"last_review_status\":\"\",\"last_review_timestamp\":\"\",\"reviews_completed\":0,\"task_description\":\"\"}"
+        render_state_fields \
+            session_id="$effective_sid" \
+            phase="" \
+            iteration=0 \
+            max_iterations="$CODEX_MAX_ITERATIONS" \
+            last_review_status="" \
+            last_review_timestamp="" \
+            reviews_completed=0 \
+            task_description=""
     fi
 }
 
@@ -34,16 +42,15 @@ cmd_reset() {
         local session_id task_desc
         session_id="$(get_effective_session_id)"
         task_desc="$(read_state_field "task_description")"
-        write_state "{
-  \"session_id\": \"$session_id\",
-  \"phase\": \"\",
-  \"iteration\": 0,
-  \"max_iterations\": $CODEX_MAX_ITERATIONS,
-  \"last_review_status\": \"\",
-  \"last_review_timestamp\": \"\",
-  \"reviews_completed\": 0,
-  \"task_description\": \"$task_desc\"
-}"
+        write_state_fields \
+            session_id="$session_id" \
+            phase="" \
+            iteration=0 \
+            max_iterations="$CODEX_MAX_ITERATIONS" \
+            last_review_status="" \
+            last_review_timestamp="" \
+            reviews_completed=0 \
+            task_description="$task_desc"
         write_status
         echo "Reset complete (session_id preserved)."
     fi
@@ -71,22 +78,50 @@ cmd_set() {
     local field="${1:?Usage: codex-state.sh set <field> <value>}"
     local value="${2:?Usage: codex-state.sh set <field> <value>}"
 
-    if [[ ! -f "$STATE_FILE" ]]; then
-        write_state "{
-  \"session_id\": \"\",
-  \"phase\": \"\",
-  \"iteration\": 0,
-  \"max_iterations\": 3,
-  \"last_review_status\": \"\",
-  \"last_review_timestamp\": \"\",
-  \"reviews_completed\": 0,
-  \"task_description\": \"\"
-}"
+    case " $STATE_STRING_FIELDS $STATE_NUMBER_FIELDS " in
+        *" $field "*) ;;
+        *)
+            echo "ERROR: Unsupported state field: $field" >&2
+            echo "Known fields: $STATE_STRING_FIELDS $STATE_NUMBER_FIELDS" >&2
+            exit 1
+            ;;
+    esac
+
+    # The whole file is rewritten from its current values with the one field
+    # replaced. Patching the stored text in place could only reach the fields
+    # written as JSON strings, so the three counters stayed as they were while
+    # the command still reported the new value.
+    local state_json=""
+    if [[ -f "$STATE_FILE" ]]; then
+        state_json="$(<"$STATE_FILE")"
     fi
 
-    local tmp
-    tmp=$(sed "s|\"$field\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"$field\": \"$value\"|" "$STATE_FILE")
-    echo "$tmp" > "$STATE_FILE"
+    local session_id phase last_review_status last_review_timestamp task_description
+    local iteration max_iterations reviews_completed
+    session_id="$(read_state_field session_id "$state_json")"
+    phase="$(read_state_field phase "$state_json")"
+    last_review_status="$(read_state_field last_review_status "$state_json")"
+    last_review_timestamp="$(read_state_field last_review_timestamp "$state_json")"
+    task_description="$(read_state_field task_description "$state_json")"
+    iteration="$(read_state_number iteration "$state_json")"
+    reviews_completed="$(read_state_number reviews_completed "$state_json")"
+    if state_has_field max_iterations "$state_json"; then
+        max_iterations="$(read_state_number max_iterations "$state_json")"
+    else
+        max_iterations="$CODEX_MAX_ITERATIONS"
+    fi
+
+    printf -v "$field" '%s' "$value"
+
+    write_state_fields \
+        session_id="$session_id" \
+        phase="$phase" \
+        iteration="$iteration" \
+        max_iterations="$max_iterations" \
+        last_review_status="$last_review_status" \
+        last_review_timestamp="$last_review_timestamp" \
+        reviews_completed="$reviews_completed" \
+        task_description="$task_description"
     write_status
     echo "Set $field = $value"
 }
@@ -109,7 +144,7 @@ case "${1:-}" in
         echo "  reset             Reset iterations/phase (keep session_id)"
         echo "  reset --full      Full reset + delete notes"
         echo "  get <field>       Get a single field (special: 'verdict' reads verdict.txt)"
-        echo "  set <field> <val> Set a field (e.g. session_id)"
+        echo "  set <field> <val> Set a field: $STATE_STRING_FIELDS $STATE_NUMBER_FIELDS"
         exit 1
         ;;
 esac

--- a/plugins/codex-review/skills/codex-review/scripts/common.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/common.sh
@@ -169,15 +169,77 @@ get_effective_session_id() {
     echo "$sid"
 }
 
-# --- Task label for state.json ---
+# --- A value state.json can store and give back unchanged ---
 # Values in state.json are written into string literals and read back with a
-# quote-delimited grep that does not decode JSON escapes. So the label has to be
-# a string that survives that round trip unchanged: one line, no double quote
-# (readers cut the value there), no backslash and no control character (a
-# JSON-escaped one would be read back as the escape itself, e.g. C:\tmp coming
-# out as C:\\tmp). Anything else is refused rather than rewritten — a mangled
-# label in front of every reader is worse than an error, and only the caller
-# knows how to name its own task in one line.
+# quote-delimited match that does not decode JSON escapes. So a stored value has
+# to survive that round trip unchanged: one line, no double quote (readers cut
+# the value there), no backslash and no control character (a JSON-escaped one
+# would be read back as the escape itself, e.g. C:\tmp coming out as C:\\tmp).
+# Anything else is refused rather than rewritten — a mangled value in front of
+# every reader is worse than an error, and only the caller knows what it meant
+# to store.
+#
+# `what` names the value in the message; `hint` says how to fix it. Prints the
+# value exactly as it came in; on rejection prints the reason to stderr and
+# returns 1 (the caller must pass that on — a bare exit inside $(...) would only
+# leave the subshell).
+state_string_value() {
+    local value="$1"
+    local what="$2"
+    local hint="$3"
+
+    if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+        echo "ERROR: $what must be a single line. $hint" >&2
+        return 1
+    fi
+    if [[ "$value" == *[$'\001'-$'\037']* ]]; then
+        echo "ERROR: $what contains control characters. $hint" >&2
+        return 1
+    fi
+    if [[ "$value" == *'"'* ]]; then
+        echo "ERROR: $what must not contain a double quote — every reader of state.json cuts the value there. $hint" >&2
+        return 1
+    fi
+    if [[ "$value" == *'\'* ]]; then
+        echo "ERROR: $what must not contain a backslash — readers of state.json do not decode JSON escapes, so it would come back doubled. $hint" >&2
+        return 1
+    fi
+
+    printf '%s' "$value"
+}
+
+# --- A counter state.json can store and this script can add to ---
+# The counters are written as JSON numbers, so only a canonical decimal is
+# storable: a leading zero produces a file no parser accepts. The digit limit
+# keeps the stored value inside the range shell arithmetic adds to — a counter
+# at the edge of that range wraps to a negative on the next +1, and the limit
+# check that guards a review cycle would never fire again.
+#
+# `what` names the value in the message; `hint` says how to fix it. Prints the
+# value as it came in; on rejection prints the reason to stderr and returns 1.
+STATE_COUNTER_MAX_DIGITS=9
+
+state_counter_value() {
+    local value="$1"
+    local what="$2"
+    local hint="$3"
+
+    if [[ ! "$value" =~ ^(0|[1-9][0-9]*)$ ]]; then
+        echo "ERROR: $what expects a whole number without a leading zero, got: $value. $hint" >&2
+        return 1
+    fi
+    if [[ ${#value} -gt $STATE_COUNTER_MAX_DIGITS ]]; then
+        echo "ERROR: $what is ${#value} digits, the limit is $STATE_COUNTER_MAX_DIGITS. $hint" >&2
+        return 1
+    fi
+
+    printf '%s' "$value"
+}
+
+# --- Task label for state.json ---
+# The label is a stored value, so it is checked as one first, and then against
+# what a name has to be on top of that: present, one line the caller can read
+# back in STATUS.md, and short enough to sit on that line.
 #
 # Prints the label exactly as it came in; on rejection prints the reason to stderr and
 # returns 1 (the caller must pass that on — a bare exit inside $(...) would only
@@ -191,22 +253,7 @@ task_label_for_state() {
     # Everything is checked on the value as it arrived. Nothing here rewrites
     # the label — not even trimming it, which would put a name in state.json
     # that the caller never wrote.
-    if [[ "$label" == *$'\n'* || "$label" == *$'\r'* ]]; then
-        echo "ERROR: task label must be a single line. $hint" >&2
-        return 1
-    fi
-    if [[ "$label" == *[$'\001'-$'\037']* ]]; then
-        echo "ERROR: task label contains control characters. $hint" >&2
-        return 1
-    fi
-    if [[ "$label" == *'"'* ]]; then
-        echo "ERROR: task label must not contain a double quote — every reader of state.json cuts the value there. $hint" >&2
-        return 1
-    fi
-    if [[ "$label" == *'\'* ]]; then
-        echo "ERROR: task label must not contain a backslash — readers of state.json do not decode JSON escapes, so it would come back doubled. $hint" >&2
-        return 1
-    fi
+    state_string_value "$label" "task label" "$hint" > /dev/null || return 1
 
     if [[ -z "$label" ]]; then
         echo "ERROR: task label is empty. $hint" >&2
@@ -224,6 +271,103 @@ task_label_for_state() {
     # No escaping: everything that would need it has been refused above, so the
     # label reaches every reader exactly as the caller wrote it.
     printf '%s' "$label"
+}
+
+# --- Fields of state.json, in the order they are written ---
+# Every writer used to carry its own copy of the file's literal, and a field
+# added to one copy reached the file only through that one writer. These two
+# lists and render_state_fields are the single description of the file's shape.
+STATE_STRING_FIELDS="session_id phase last_review_status last_review_timestamp task_description"
+STATE_NUMBER_FIELDS="iteration max_iterations reviews_completed"
+
+# --- Is a field present in a state.json snapshot? ---
+# read_state_field answers "" and read_state_number answers 0 for a field that
+# is absent — the same answer they give for an empty string and for a zero. A
+# caller that has to tell an absent field from a written one asks here.
+state_has_field() {
+    local field="$1"
+    local state_json="$2"
+    local pattern="\"${field}\"[[:space:]]*:"
+    [[ "$state_json" =~ $pattern ]]
+}
+
+# --- Render state.json from named fields ---
+# Called as: render_state_fields session_id=... phase=... — every field of the
+# file, by name. Names rather than positions: three of the fields are counters
+# that read alike, and a writer that swapped two of them would produce a
+# plausible file. An unknown name, a name given twice, a name left out, a
+# counter this file cannot hold and a string that state.json cannot give back
+# unchanged are all errors — every path that writes the file passes through
+# here, so a value that would break it never reaches the disk.
+render_state_fields() {
+    local session_id phase last_review_status last_review_timestamp task_description
+    local iteration max_iterations reviews_completed
+    local seen=" "
+    local arg key value field
+
+    for arg in "$@"; do
+        if [[ "$arg" != *=* ]]; then
+            echo "ERROR: state field must be given as name=value, got: $arg" >&2
+            return 1
+        fi
+        key="${arg%%=*}"
+        value="${arg#*=}"
+
+        case " $STATE_STRING_FIELDS $STATE_NUMBER_FIELDS " in
+            *" $key "*) ;;
+            *)
+                echo "ERROR: Unsupported state field: $key" >&2
+                echo "Known fields: $STATE_STRING_FIELDS $STATE_NUMBER_FIELDS" >&2
+                return 1
+                ;;
+        esac
+        if [[ "$seen" == *" $key "* ]]; then
+            echo "ERROR: State field given twice: $key" >&2
+            return 1
+        fi
+        case " $STATE_NUMBER_FIELDS " in
+            *" $key "*)
+                state_counter_value "$value" "$key" \
+                    "Pass a counter state.json can store." > /dev/null || return 1
+                ;;
+        esac
+        case " $STATE_STRING_FIELDS " in
+            *" $key "*)
+                state_string_value "$value" "$key" \
+                    "Pass a value state.json can store as written." > /dev/null || return 1
+                ;;
+        esac
+
+        printf -v "$key" '%s' "$value"
+        seen="$seen$key "
+    done
+
+    for field in $STATE_STRING_FIELDS $STATE_NUMBER_FIELDS; do
+        if [[ "$seen" != *" $field "* ]]; then
+            echo "ERROR: State field not given: $field" >&2
+            return 1
+        fi
+    done
+
+    cat <<STATE
+{
+  "session_id": "$session_id",
+  "phase": "$phase",
+  "iteration": $iteration,
+  "max_iterations": $max_iterations,
+  "last_review_status": "$last_review_status",
+  "last_review_timestamp": "$last_review_timestamp",
+  "reviews_completed": $reviews_completed,
+  "task_description": "$task_description"
+}
+STATE
+}
+
+# --- Write state.json from named fields ---
+write_state_fields() {
+    local json
+    json="$(render_state_fields "$@")" || return 1
+    write_state "$json"
 }
 
 # --- Write state.json ---

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -13,6 +13,7 @@ test/
 ├── test-auto-approve-plan.sh   # unit tests for the auto-approve hook
 ├── test-integration.sh         # path-contract tests (hook ↔ state dir)
 ├── test-state-cache.sh         # cached state path and batched STATUS.md reads
+├── test-state-set.sh           # `codex-state.sh set`, one state.json writer
 ├── test-description-file.sh    # --description-file, per-attempt logs, saved request
 ├── test-severity-calibration.sh # severity scale, finding headings, verdict threshold
 ├── test-exec-flags.sh          # model and reasoning effort on every codex exec call
@@ -92,6 +93,38 @@ Run:
 
 ```sh
 sh plugins/codex-review/test/test-state-cache.sh
+```
+
+## test-state-set.sh
+
+Regression tests for `codex-state.sh set` and for `render_state_fields` in
+`common.sh` — the one place that describes the shape of `state.json`.
+
+Scenarios:
+
+1. The three counters (`iteration`, `max_iterations`, `reviews_completed`) are
+   actually written, a counter can be set back to zero, and `STATUS.md` follows
+   the stored numbers.
+2. An unknown field name and a counter value that is not a non-negative integer
+   exit `1` with a message naming the field, and leave `state.json` byte for
+   byte as it was.
+3. Writing one field keeps every other field, `reviews_completed` included.
+4. A value `state.json` could not give back unchanged — a double quote, a
+   backslash, a second line, a control character — is refused rather than
+   stored or repaired, and an ordinary value is stored exactly as passed.
+5. `set` against a missing `state.json` writes the whole file, with
+   `max_iterations` taken from `config.env`.
+6. The renderer refuses a field left out, a field given twice, and an argument
+   without a name; neither entry script carries its own copy of the file's
+   literal.
+
+Does **not** require the `codex` binary. JSON validity is asserted through
+`python3` or `jq`; that one assertion is skipped if neither is available.
+
+Run:
+
+```sh
+sh plugins/codex-review/test/test-state-set.sh
 ```
 
 ## test-description-file.sh
@@ -313,5 +346,5 @@ scenario — as an `init` task and as a code description, not as plans:
 
 ## Exit codes
 
-All six scripts exit `0` on success and `1` if any assertion failed.
+All eight scripts exit `0` on success and `1` if any assertion failed.
 `test-e2e.sh` additionally exits `0` (skip) when `CODEX_E2E` is not set.

--- a/plugins/codex-review/test/test-state-set.sh
+++ b/plugins/codex-review/test/test-state-set.sh
@@ -1,0 +1,342 @@
+#!/bin/sh
+# Regression tests for `codex-state.sh set` and the single renderer every
+# writer of state.json goes through.
+#
+# Does NOT require the `codex` binary — the state script never calls it.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROD_SCRIPTS="$SCRIPT_DIR/../skills/codex-review/scripts"
+STATE_CMD="$PROD_SCRIPTS/codex-state.sh"
+COMMON="$PROD_SCRIPTS/common.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+    printf '  PASS: %s\n' "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf '  FAIL: %s\n' "$1"
+    [ -n "${2:-}" ] && printf '    %s\n' "$2"
+    return 0
+}
+
+assert_eq() {
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1" "expected: [$2]; actual: [$3]"
+    fi
+}
+
+assert_contains() {
+    case "$3" in
+        *"$2"*) pass "$1" ;;
+        *) fail "$1" "missing '$2' in: $3" ;;
+    esac
+}
+
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+REPO="$TEST_ROOT/repo"
+mkdir -p "$REPO"
+(
+    cd "$REPO"
+    git init -q -b main
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    git commit -q --allow-empty -m "init"
+    mkdir -p .codex-review
+    printf 'CODEX_MAX_ITERATIONS=7\n' > .codex-review/config.env
+)
+STATE_DIR="$REPO/.codex-review/main"
+STATE_FILE="$STATE_DIR/state.json"
+
+# Runs `set` and prints "<exit code>|<stderr and stdout on one line>".
+run_set() {
+    _out="$(cd "$REPO" && bash "$STATE_CMD" set "$1" "$2" 2>&1)" && _rc=0 || _rc=$?
+    printf '%s|%s\n' "$_rc" "$(printf '%s' "$_out" | tr '\n' ' ')"
+}
+
+rc_of() { printf '%s' "${1%%|*}"; }
+msg_of() { printf '%s' "${1#*|}"; }
+
+# Reads a value out of state.json without a JSON parser: strings come back
+# without their quotes, numbers as written.
+field() {
+    sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\\(.*\\)\".*/\\1/p" "$STATE_FILE" | head -1
+}
+number() {
+    sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\\([0-9][0-9]*\\).*/\\1/p" "$STATE_FILE" | head -1
+}
+
+JSON_CHECK=""
+if command -v python3 >/dev/null 2>&1; then
+    JSON_CHECK="python3"
+elif command -v jq >/dev/null 2>&1; then
+    JSON_CHECK="jq"
+fi
+
+assert_valid_json() {
+    case "$JSON_CHECK" in
+        python3)
+            if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$STATE_FILE" 2>/dev/null; then
+                pass "$1"
+            else
+                fail "$1" "not valid JSON: $(cat "$STATE_FILE")"
+            fi
+            ;;
+        jq)
+            if jq -e . "$STATE_FILE" >/dev/null 2>&1; then
+                pass "$1"
+            else
+                fail "$1" "not valid JSON: $(cat "$STATE_FILE")"
+            fi
+            ;;
+        *)
+            printf '  SKIP: %s (no python3 or jq)\n' "$1"
+            ;;
+    esac
+}
+
+# ============================
+# Test 1: counters are written
+# ============================
+printf 'Test 1: set writes the counters, not just the strings\n'
+
+(cd "$REPO" && bash "$STATE_CMD" set session_id sess-1 >/dev/null)
+r="$(run_set iteration 2)"
+assert_eq "set iteration exits 0" "0" "$(rc_of "$r")"
+assert_eq "iteration is stored" "2" "$(number iteration)"
+
+r="$(run_set max_iterations 9)"
+assert_eq "max_iterations is stored" "9" "$(number max_iterations)"
+
+r="$(run_set reviews_completed 3)"
+assert_eq "reviews_completed is stored" "3" "$(number reviews_completed)"
+
+r="$(run_set iteration 0)"
+assert_eq "a counter can be set back to zero" "0" "$(number iteration)"
+
+assert_contains "STATUS.md follows the stored counters" "Iteration: 0/9" \
+    "$(cat "$STATE_DIR/STATUS.md")"
+
+# ============================
+# Test 2: a refused write changes nothing
+# ============================
+printf 'Test 2: an unusable field or value is refused, and nothing is written\n'
+
+(cd "$REPO" && bash "$STATE_CMD" set iteration 4 >/dev/null)
+before="$(cat "$STATE_FILE")"
+
+r="$(run_set bogus_field 5)"
+assert_eq "an unknown field exits 1" "1" "$(rc_of "$r")"
+assert_contains "an unknown field says so" "Unsupported state field: bogus_field" "$(msg_of "$r")"
+assert_contains "an unknown field lists the known ones" "reviews_completed" "$(msg_of "$r")"
+assert_eq "an unknown field leaves state.json untouched" "$before" "$(cat "$STATE_FILE")"
+
+for bad in abc -1 2.5 "" 08 9999999999; do
+    r="$(run_set iteration "$bad")"
+    assert_eq "iteration refuses [$bad]" "1" "$(rc_of "$r")"
+done
+assert_contains "a value that is not a number says what it expects" \
+    "iteration expects a whole number without a leading zero" "$(msg_of "$(run_set iteration abc)")"
+assert_contains "a counter too long to add to says so" \
+    "iteration is 10 digits, the limit is 9" "$(msg_of "$(run_set iteration 9999999999)")"
+assert_eq "a refused counter leaves state.json untouched" "$before" "$(cat "$STATE_FILE")"
+
+# ============================
+# Test 3: the other fields survive a write
+# ============================
+printf 'Test 3: writing one field keeps every other field\n'
+
+(
+    cd "$REPO"
+    bash "$STATE_CMD" set session_id sess-keep >/dev/null
+    bash "$STATE_CMD" set phase code >/dev/null
+    bash "$STATE_CMD" set iteration 2 >/dev/null
+    bash "$STATE_CMD" set max_iterations 6 >/dev/null
+    bash "$STATE_CMD" set reviews_completed 1 >/dev/null
+    bash "$STATE_CMD" set task_description "Keep every field" >/dev/null
+    bash "$STATE_CMD" set last_review_timestamp 2026-09-04T00:00:00Z >/dev/null
+    bash "$STATE_CMD" set last_review_status CHANGES_REQUESTED >/dev/null
+)
+assert_eq "session_id survives" "sess-keep" "$(field session_id)"
+assert_eq "phase survives" "code" "$(field phase)"
+assert_eq "iteration survives" "2" "$(number iteration)"
+assert_eq "max_iterations survives" "6" "$(number max_iterations)"
+assert_eq "reviews_completed survives" "1" "$(number reviews_completed)"
+assert_eq "task_description survives" "Keep every field" "$(field task_description)"
+assert_eq "last_review_timestamp survives" "2026-09-04T00:00:00Z" "$(field last_review_timestamp)"
+assert_eq "last_review_status is the one just written" "CHANGES_REQUESTED" "$(field last_review_status)"
+
+# ============================
+# Test 4: values state.json cannot give back are refused
+# ============================
+printf 'Test 4: a value that would not survive storage is refused, not repaired\n'
+
+before="$(cat "$STATE_FILE")"
+
+r="$(run_set task_description 'fix "the" bug')"
+assert_eq "a double quote exits 1" "1" "$(rc_of "$r")"
+assert_contains "a double quote names the field" "task_description must not contain a double quote" \
+    "$(msg_of "$r")"
+
+r="$(run_set task_description 'C:\tmp\out')"
+assert_eq "a backslash exits 1" "1" "$(rc_of "$r")"
+
+r="$(run_set session_id "$(printf 'two\nlines')")"
+assert_eq "a second line exits 1" "1" "$(rc_of "$r")"
+
+r="$(run_set phase "$(printf 'a\tb')")"
+assert_eq "a control character exits 1" "1" "$(rc_of "$r")"
+
+assert_eq "a refused value leaves state.json untouched" "$before" "$(cat "$STATE_FILE")"
+assert_valid_json "state.json stays valid JSON"
+
+r="$(run_set task_description 'Fix the parser: keep spaces')"
+assert_eq "an ordinary value is stored as written" "Fix the parser: keep spaces" "$(field task_description)"
+
+# ============================
+# Test 5: a first write builds the whole file
+# ============================
+printf 'Test 5: set on a missing state.json writes every field\n'
+
+rm -f "$STATE_FILE"
+r="$(run_set phase implementing)"
+assert_eq "the first set exits 0" "0" "$(rc_of "$r")"
+assert_eq "phase is the value just set" "implementing" "$(field phase)"
+assert_eq "max_iterations comes from config.env" "7" "$(number max_iterations)"
+assert_eq "iteration starts at zero" "0" "$(number iteration)"
+assert_eq "reviews_completed starts at zero" "0" "$(number reviews_completed)"
+assert_valid_json "a file written from scratch is valid JSON"
+
+# ============================
+# Test 6: one renderer describes the file
+# ============================
+printf 'Test 6: state.json has a single writer\n'
+
+render() {
+    bash -c '
+        set -euo pipefail
+        source "$1"
+        shift
+        render_state_fields "$@"
+    ' _ "$COMMON" "$@" 2>&1
+}
+render_rc() {
+    render "$@" >/dev/null 2>&1 && printf '0' || printf '1'
+}
+
+full_args='session_id=s phase=code iteration=1 max_iterations=5 last_review_status=APPROVED last_review_timestamp=t reviews_completed=1 task_description=Task'
+
+# shellcheck disable=SC2086
+assert_eq "every field given renders" "0" "$(render_rc $full_args)"
+# shellcheck disable=SC2086
+assert_contains "the rendered file carries the counter as a number" '"iteration": 1,' "$(render $full_args)"
+
+assert_eq "a missing field is an error" "1" \
+    "$(render_rc session_id=s phase=code iteration=1 max_iterations=5)"
+assert_contains "a missing field is named" "State field not given" \
+    "$(render session_id=s phase=code iteration=1 max_iterations=5)"
+
+# shellcheck disable=SC2086
+assert_eq "a field given twice is an error" "1" "$(render_rc $full_args phase=plan)"
+# shellcheck disable=SC2086
+assert_eq "an argument without a name is an error" "1" "$(render_rc $full_args stray)"
+
+for script in codex-review.sh codex-state.sh; do
+    if grep -q '"max_iterations"[[:space:]]*:' "$PROD_SCRIPTS/$script"; then
+        fail "$script writes state.json through the shared renderer" \
+            "it still carries its own copy of the file's literal"
+    else
+        pass "$script writes state.json through the shared renderer"
+    fi
+done
+
+# ============================
+# Test 7: the iteration limit is checked before anything happens
+# ============================
+printf 'Test 7: a limit state.json cannot hold stops the run before it starts\n'
+
+REVIEW_CMD="$PROD_SCRIPTS/codex-review.sh"
+LIMIT_REPO="$TEST_ROOT/limit-repo"
+STUB_BIN="$TEST_ROOT/stub-bin"
+CODEX_CALLED="$TEST_ROOT/codex-was-called"
+mkdir -p "$LIMIT_REPO" "$STUB_BIN"
+(
+    cd "$LIMIT_REPO"
+    git init -q -b main
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    git commit -q --allow-empty -m "init"
+)
+cat > "$STUB_BIN/codex" <<STUB
+#!/bin/sh
+if [ "\$1" = "--version" ]; then
+    echo "codex-stub"
+    exit 0
+fi
+touch "$CODEX_CALLED"
+exit 0
+STUB
+chmod +x "$STUB_BIN/codex"
+
+(cd "$LIMIT_REPO" && bash "$STATE_CMD" set session_id sess-limit >/dev/null)
+LIMIT_STATE="$LIMIT_REPO/.codex-review/main/state.json"
+
+# Every setting `load_config` reads is cleared, and so is the reviewer guard:
+# run from inside a review, an inherited CODEX_REVIEWER=1 would abort the run
+# before it ever reached the limit and answer these assertions for the wrong
+# reason.
+run_init() {
+    (
+        unset CODEX_REVIEWER CODEX_MODEL CODEX_REASONING_EFFORT \
+              CODEX_MAX_ITERATIONS CODEX_YOLO CODEX_SESSION_ID AUTO_REVIEW \
+              CODEX_REVIEWER_PROMPT CODEX_PLAN_GUIDE CODEX_CODE_GUIDE \
+              CODEX_SEVERITY_CALIBRATION
+        cd "$LIMIT_REPO" && PATH="$STUB_BIN:$PATH" \
+            bash "$REVIEW_CMD" init "task" --max-iter "$1" 2>&1
+    )
+}
+
+# Asserts the whole refusal: the exit code, the message, and that the run cost
+# nothing — no codex call, no archive, the stored state untouched.
+assert_limit_refused() {
+    _label="$1"
+    _value="$2"
+    rm -f "$CODEX_CALLED"
+    # Read defensively: a run that spends the state instead of refusing leaves
+    # no file behind, and this assertion has to report that rather than die.
+    _before="$(cat "$LIMIT_STATE" 2>/dev/null || printf '<no state.json>')"
+    _out="$(run_init "$_value")" && _rc=0 || _rc=$?
+
+    assert_eq "$_label exits 1" "1" "$_rc"
+    assert_contains "$_label names the option to fix" "--max-iter" "$_out"
+    assert_contains "$_label names the value it refused" "the iteration limit" "$_out"
+    if [ -f "$CODEX_CALLED" ]; then
+        fail "$_label calls no codex" "the stub recorded a call"
+    else
+        pass "$_label calls no codex"
+    fi
+    if [ -d "$LIMIT_REPO/.codex-review/archive" ]; then
+        fail "$_label archives nothing" "an archive directory was created"
+    else
+        pass "$_label archives nothing"
+    fi
+    assert_eq "$_label leaves the stored state untouched" "$_before" \
+        "$(cat "$LIMIT_STATE" 2>/dev/null || printf '<no state.json>')"
+}
+
+assert_limit_refused "a limit that is not a number" "abc"
+assert_limit_refused "a limit with a leading zero" "08"
+assert_limit_refused "a limit too long to add to" "9999999999"
+
+printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Why

`codex-state.sh set` reported writes it never made.

`set` patched `state.json` with a single `sed` whose pattern required a quoted
value. The three counters — `iteration`, `max_iterations`, `reviews_completed` —
are JSON numbers, so the substitution never matched: the command printed
`Set <field> = <value>` and exited 0 while the file kept its old number. A
mistyped field name reported success the same way, and a value carrying a double
quote or a backslash produced a file no JSON parser accepts.

Reproduced on a scratch repository before the change:

```
$ codex-state.sh set iteration 2      → "Set iteration = 2", exit 0, file still holds 0
$ codex-state.sh set bogus_field 5    → "Set bogus_field = 5", exit 0
$ codex-state.sh set task_description 'fix "the" bug'  → exit 0, invalid JSON
```

The same defects were found and fixed in a downstream fork of this plugin; this
is the port back, verified against the code here rather than applied blind.

## What changed

**One writer for `state.json`.** `render_state_fields` in `common.sh` takes every
field by name (`name=value`) and is the only place that describes the file's
shape. Names rather than positions: three of the fields are counters that read
alike, and a writer that swapped two of them would produce a plausible file.
Before this change the file's literal was copied into six call sites, which is
how `reviews_completed` came to be written by some of them only.

**The renderer is the barrier.** It refuses an unknown field, a field given
twice, a field left out, a counter the file cannot hold, and a string
`state.json` could not give back unchanged. Every write path goes through it, so
an unusable value never reaches the disk.

**Values are refused, not repaired.** The check that already kept a task label
storable is split: `state_string_value` holds the rules that apply to any stored
value and is called by the renderer for every string field; `task_label_for_state`
keeps the rules that belong to a name (non-empty, no edge spaces, 200 characters)
and calls the shared check first, so `init` still fails before a session exists.

**Counters are canonical decimals.** `state_counter_value` accepts only
`0|[1-9][0-9]*` and caps the value at nine digits: a leading zero produces a file
no parser accepts, and a value at the edge of the arithmetic range wraps to a
negative on the next `+1`, past the check that ends a review cycle. The iteration
limit passes the same check as soon as `--max-iter` and `CODEX_MAX_ITERATIONS`
are both known — before the `codex --version` probe, before `init` archives
anything or opens a session.

`set` now rewrites the file through the renderer from the stored values with the
one named field replaced, and reports nothing when it refuses.

## Checks

New `test-state-set.sh`: 67 assertions, 41 of which fail when run against the
scripts as they were before this change. The six existing suites pass unchanged
(48 / 8 / 11 / 12 / 47 / 80). `bash -n` and `shellcheck` on every changed script —
the only shellcheck output is a pre-existing `SC1003` on a line this change moved
verbatim. `markdownlint-cli2` on the changed markdown reports the same count as
`main`. Cross-agent review with codex-review: `APPROVED`.

Three findings from that review in code this change does not touch are left as
they are, by the author's decision: the text-fallback verdict parser reading
"Not APPROVED" as approval (its own change, next), the write that truncates the
live file before rewriting it, and an empty string field read back as the number
`0`.
