### PR TITLE
fix(codex-review): keep the review state and its archive intact

### DIFF
--- a/plugins/codex-review/.claude-plugin/plugin.json
+++ b/plugins/codex-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codex-review",
   "description": "Cross-agent review workflow: Claude implements, Codex reviews",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "author": {
     "name": "Polyakov"
   },

--- a/plugins/codex-review/skills/codex-review/SKILL.md
+++ b/plugins/codex-review/skills/codex-review/SKILL.md
@@ -139,6 +139,11 @@ bash scripts/codex-state.sh set phase implementing  # Обновить фазу
 bash scripts/codex-state.sh set iteration 2       # Откатить счётчик кругов
 ```
 
+`get` возвращает значение поля как оно записано: пустое строковое поле — пустой
+строкой, счётчик — числом. Незнакомое имя поля — ошибка с кодом возврата 1.
+Особые имена: `session_id` (приоритет у `config.env`) и `verdict` (из
+`verdict.txt`).
+
 `set` принимает поля `session_id`, `phase`, `iteration`, `max_iterations`,
 `reviews_completed`, `last_review_status`, `last_review_timestamp`,
 `task_description`. Неизвестное имя поля, нецелое значение счётчика и значение

--- a/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-review.sh
@@ -303,7 +303,17 @@ save_note() {
     local phase="$1"
     local iteration="$2"
     local content="$3"
-    local note_file="$STATE_DIR/notes/${phase}-review-${iteration}.md"
+    # The iteration number is not unique over the life of a branch:
+    # `codex-state.sh reset` starts the count over while the notes of the
+    # previous cycle stay on disk. A taken name is stepped over the way
+    # next_attempt_log steps over a taken log.
+    local note_base="$STATE_DIR/notes/${phase}-review-${iteration}"
+    local note_file="${note_base}.md"
+    local attempt=2
+    while [[ -e "$note_file" ]]; do
+        note_file="${note_base}.${attempt}.md"
+        attempt=$((attempt + 1))
+    done
     {
         echo "# $(echo "$phase" | awk '{print toupper(substr($0,1,1)) substr($0,2)}') Review #${iteration}"
         echo "Date: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/codex-state.sh
@@ -66,12 +66,21 @@ cmd_get() {
         parse_verdict_file "$STATE_DIR/verdict.txt"
         return
     fi
-    local val
-    val="$(read_state_field "$field")"
-    if [[ -z "$val" ]]; then
-        val="$(read_state_number "$field")"
-    fi
-    echo "$val"
+    # The reader is chosen by the field, not by what the first one returned:
+    # asking a string reader for an empty value and then retrying with the
+    # numeric one answered 0 for a field that holds an empty string, and for a
+    # field that does not exist at all.
+    case " $STATE_STRING_FIELDS " in
+        *" $field "*) read_state_field "$field"; return ;;
+    esac
+    case " $STATE_NUMBER_FIELDS " in
+        *" $field "*) read_state_number "$field"; return ;;
+    esac
+
+    echo "ERROR: Unsupported state field: $field" >&2
+    echo "Known fields: $STATE_STRING_FIELDS $STATE_NUMBER_FIELDS" >&2
+    echo "Also readable: session_id (config.env wins), verdict (from verdict.txt)" >&2
+    exit 1
 }
 
 cmd_set() {

--- a/plugins/codex-review/skills/codex-review/scripts/common.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/common.sh
@@ -371,10 +371,39 @@ write_state_fields() {
 }
 
 # --- Write state.json ---
+# The file is replaced, never truncated in place: a write that dies part way
+# through — a full disk above all — would otherwise leave the session with an
+# empty or half-written state.json and nothing to fall back on. The temporary
+# file sits in the same directory, so the rename that publishes it is atomic.
 write_state() {
     local json="$1"
     ensure_state_dir
-    echo "$json" > "$STATE_DIR/state.json"
+    local state_file="$STATE_DIR/state.json"
+    local tmp_file="$STATE_DIR/.state.json.$$"
+
+    # A write killed by a signal leaves its temporary file behind — the cleanup
+    # below never runs for it. The name carries the pid that made it, so an
+    # orphan can be told from the file of a run that is still going; a pid that
+    # answers is left alone, which also covers a pid reused by something else.
+    local orphan orphan_pid
+    for orphan in "$STATE_DIR"/.state.json.*; do
+        [[ -e "$orphan" ]] || continue
+        orphan_pid="${orphan##*.}"
+        [[ "$orphan_pid" =~ ^[0-9]+$ ]] || continue
+        kill -0 "$orphan_pid" 2>/dev/null && continue
+        rm -f "$orphan"
+    done
+
+    if ! printf '%s\n' "$json" > "$tmp_file"; then
+        rm -f "$tmp_file"
+        echo "ERROR: Failed to write $tmp_file." >&2
+        return 1
+    fi
+    if ! mv "$tmp_file" "$state_file"; then
+        rm -f "$tmp_file"
+        echo "ERROR: Failed to replace $state_file." >&2
+        return 1
+    fi
 }
 
 # --- Write STATUS.md from current state.json ---

--- a/plugins/codex-review/skills/codex-review/scripts/common.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/common.sh
@@ -484,8 +484,31 @@ archive_previous_session() {
 
     local timestamp
     timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
-    local archive_dir="$review_root/archive/${timestamp}"
-    mkdir -p "$archive_dir/notes"
+    # Two sessions archived inside the same second would otherwise share a
+    # directory and mix their artefacts. `mkdir` without -p fails when the
+    # directory is already there, and that failure is the claim: whoever
+    # created it owns that name, and the next one moves on to a suffix.
+    # Only an existing directory sends the loop on; every other failure --
+    # a read-only or full filesystem, a denied permission -- ends the archiver.
+    if ! mkdir -p "$review_root/archive"; then
+        echo "ERROR: Failed to create $review_root/archive. Nothing was archived." >&2
+        return 1
+    fi
+    local archive_base="$review_root/archive/${timestamp}"
+    local archive_dir="$archive_base"
+    local suffix=2
+    while ! mkdir "$archive_dir" 2>/dev/null; do
+        if [[ ! -d "$archive_dir" ]]; then
+            echo "ERROR: Failed to create archive directory $archive_dir. Nothing was archived." >&2
+            return 1
+        fi
+        archive_dir="${archive_base}-${suffix}"
+        suffix=$((suffix + 1))
+    done
+    if ! mkdir -p "$archive_dir/notes"; then
+        echo "ERROR: Failed to create $archive_dir/notes. Nothing was archived." >&2
+        return 1
+    fi
 
     # Generate summary.json before moving artifacts (non-critical, must not block archiving)
     generate_archive_summary "$state_dir" "$archive_dir" "$timestamp" || \

--- a/plugins/codex-review/skills/codex-review/scripts/common.sh
+++ b/plugins/codex-review/skills/codex-review/scripts/common.sh
@@ -461,6 +461,23 @@ parse_verdict_file() {
     esac
 }
 
+# --- Move artifacts into an archive directory ---
+# A pattern that matches nothing is normal: not every session leaves notes or
+# replies. A move that fails is not — the file stays behind under a name the
+# next session reuses — so that failure travels back to the caller.
+archive_move() {
+    local dest="$1"
+    shift
+    local f
+    for f in "$@"; do
+        [[ -e "$f" ]] || continue
+        if ! mv "$f" "$dest/"; then
+            echo "ERROR: Failed to move $f into $dest." >&2
+            return 1
+        fi
+    done
+}
+
 # --- Archive previous session artifacts ---
 archive_previous_session() {
     ensure_state_dir
@@ -514,21 +531,22 @@ archive_previous_session() {
     generate_archive_summary "$state_dir" "$archive_dir" "$timestamp" || \
         echo "WARNING: Failed to generate summary.json for archive." >&2
 
-    # Move artifacts
-    for f in state.json verdict.txt last_response.txt STATUS.md; do
-        [[ -f "$state_dir/$f" ]] && mv "$state_dir/$f" "$archive_dir/"
-    done
-    mv "$state_dir"/codex-*.log "$archive_dir/" 2>/dev/null || true
+    # Move artifacts. A failure here leaves an artifact under a name the next
+    # session reuses, so it stops the archiver instead of passing for success.
+    archive_move "$archive_dir" \
+        "$state_dir/state.json" "$state_dir/verdict.txt" \
+        "$state_dir/last_response.txt" "$state_dir/STATUS.md" || return 1
+    archive_move "$archive_dir" "$state_dir"/codex-*.log || return 1
     # Requests travel with the logs of the attempts that sent them: left behind,
     # they would be overwritten once a new session reuses the attempt numbers.
-    mv "$state_dir"/codex-*.request.md "$archive_dir/" 2>/dev/null || true
+    archive_move "$archive_dir" "$state_dir"/codex-*.request.md || return 1
     # The prompts travel with them: codex-init.prompt.md carries a fixed name, so
     # a new session would overwrite it where it stands.
-    mv "$state_dir"/codex-*.prompt.md "$archive_dir/" 2>/dev/null || true
+    archive_move "$archive_dir" "$state_dir"/codex-*.prompt.md || return 1
     # So do the replies of rounds that came back without a verdict — they are
     # named after the attempt, and a new session reuses those numbers.
-    mv "$state_dir"/codex-*.reply.md "$archive_dir/" 2>/dev/null || true
-    mv "$state_dir"/notes/*.md "$archive_dir/notes/" 2>/dev/null || true
+    archive_move "$archive_dir" "$state_dir"/codex-*.reply.md || return 1
+    archive_move "$archive_dir/notes" "$state_dir"/notes/*.md || return 1
 
     echo "Previous session archived to: $archive_dir" >&2
 }

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -335,7 +335,7 @@ sh plugins/codex-review/test/test-verdict-source.sh
 ## test-state-durability.sh
 
 Regression tests for four ways the plugin used to lose or invent something it
-had on disk, and for the archiver refusing a directory it cannot make.
+had on disk, and for the archiver reporting what it could not do.
 
 Scenarios:
 
@@ -358,6 +358,9 @@ Scenarios:
    leaves the artefacts where they are. A read-only archive root covers the
    case a loop watching only `mkdir` would mistake for a name collision;
    `timeout` bounds a run that would otherwise never end.
+7. An artifact that cannot be moved into the archive stops the archiver and is
+   named in the error. A read-only state directory makes every move fail while
+   leaving the files readable.
 
 Does **not** require the `codex` binary — a stub on `PATH` plays the reviewer.
 `common.sh` is a bash script, so the calls into it run under `bash` even though

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -16,6 +16,7 @@ test/
 ├── test-state-set.sh           # `codex-state.sh set`, one state.json writer
 ├── test-failure-iteration.sh   # what a failed codex call costs
 ├── test-verdict-source.sh      # the verdict file decides, the reply never does
+├── test-state-durability.sh    # what survives a write, a reset and a second archiver
 ├── test-description-file.sh    # --description-file, per-attempt logs, saved request
 ├── test-severity-calibration.sh # severity scale, finding headings, verdict threshold
 ├── test-exec-flags.sh          # model and reasoning effort on every codex exec call
@@ -331,6 +332,43 @@ Run:
 sh plugins/codex-review/test/test-verdict-source.sh
 ```
 
+## test-state-durability.sh
+
+Regression tests for four ways the plugin used to lose or invent something it
+had on disk, and for the archiver refusing a directory it cannot make.
+
+Scenarios:
+
+1. A write that dies part way through leaves the previous `state.json` intact.
+   `ulimit -f 0` lets the file be created but not filled, which is the shape of
+   a full disk; a control write without that limit proves the call under test
+   does reach the file.
+2. A temporary file left behind by such a killed write is removed by the next
+   write, while one belonging to a process that is still running is left alone.
+3. `get` answers with what the field holds: an empty string field reads as
+   empty rather than as `0`, a counter reads as a number, and an unknown field
+   exits `1` naming what can be read.
+4. Notes of an earlier cycle survive `codex-state.sh reset` — the next cycle's
+   first round takes the next free name instead of overwriting them.
+5. Two archive runs that claim their directory at the same moment get one
+   each. Both are pinned to the same second by a `date` stub on `PATH` and
+   released together by a gate file, and they archive two state directories
+   under one review root, so they compete for the name and nothing else.
+6. An archive directory that cannot be created ends the run with an error and
+   leaves the artefacts where they are. A read-only archive root covers the
+   case a loop watching only `mkdir` would mistake for a name collision;
+   `timeout` bounds a run that would otherwise never end.
+
+Does **not** require the `codex` binary — a stub on `PATH` plays the reviewer.
+`common.sh` is a bash script, so the calls into it run under `bash` even though
+the suite itself is POSIX `sh`.
+
+Run:
+
+```sh
+sh plugins/codex-review/test/test-state-durability.sh
+```
+
 ## test-e2e.sh
 
 Opt-in end-to-end tests that exercise real `codex` / `claude` CLIs.
@@ -409,5 +447,5 @@ scenario — as an `init` task and as a code description, not as plans:
 
 ## Exit codes
 
-All ten scripts exit `0` on success and `1` if any assertion failed.
+All eleven scripts exit `0` on success and `1` if any assertion failed.
 `test-e2e.sh` additionally exits `0` (skip) when `CODEX_E2E` is not set.

--- a/plugins/codex-review/test/README.md
+++ b/plugins/codex-review/test/README.md
@@ -355,16 +355,22 @@ Scenarios:
    released together by a gate file, and they archive two state directories
    under one review root, so they compete for the name and nothing else.
 6. An archive directory that cannot be created ends the run with an error and
-   leaves the artefacts where they are. A read-only archive root covers the
-   case a loop watching only `mkdir` would mistake for a name collision;
-   `timeout` bounds a run that would otherwise never end.
+   leaves the artefacts where they are. This covers the case a loop watching
+   only `mkdir` would mistake for a name collision, and the archive root that
+   cannot be made at all.
 7. An artifact that cannot be moved into the archive stops the archiver and is
-   named in the error. A read-only state directory makes every move fail while
-   leaving the files readable.
+   named in the error.
+
+Scenarios 6 and 7 get their failures from `mkdir` and `mv` stubs that refuse the
+target named in an environment variable, so the outcome does not depend on who
+runs the suite — a file permission means nothing to a superuser, which is who
+runs a container by default.
 
 Does **not** require the `codex` binary — a stub on `PATH` plays the reviewer.
 `common.sh` is a bash script, so the calls into it run under `bash` even though
-the suite itself is POSIX `sh`.
+the suite itself is POSIX `sh`. Runs that would otherwise never end are bounded
+by `timeout`, or by `gtimeout` where GNU coreutils arrives under that name; the
+suite stops with an explanation when neither is on `PATH`.
 
 Run:
 

--- a/plugins/codex-review/test/test-state-durability.sh
+++ b/plugins/codex-review/test/test-state-durability.sh
@@ -187,5 +187,31 @@ assert_contains "an unknown field lists what can be read" "verdict" "$out"
 
 assert_eq "session_id is still readable" "test-session" "$(state_cmd get session_id)"
 
+# ============================
+# Test 4: a reset does not put the next round's note over the previous one
+# ============================
+printf 'Test 4: notes of an earlier cycle survive a reset\n'
+
+state_cmd reset >/dev/null
+run_review
+FIRST_NOTE="$STATE_DIR/notes/code-review-1.md"
+if [ -f "$FIRST_NOTE" ]; then
+    pass "the first cycle leaves its note"
+else
+    fail "the first cycle leaves its note" "no note at $FIRST_NOTE"
+fi
+FIRST_CONTENT="$(cat "$FIRST_NOTE" 2>/dev/null || printf '<no note>')"
+
+state_cmd reset >/dev/null
+run_review
+assert_eq "the first note is untouched" "$FIRST_CONTENT" \
+    "$(cat "$FIRST_NOTE" 2>/dev/null || printf '<no note>')"
+if [ -f "$STATE_DIR/notes/code-review-1.2.md" ]; then
+    pass "the new cycle's note takes the next free name"
+else
+    fail "the new cycle's note takes the next free name" \
+        "$(find "$STATE_DIR/notes" -name 'code-review-*' | tr '\n' ' ')"
+fi
+
 printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/plugins/codex-review/test/test-state-durability.sh
+++ b/plugins/codex-review/test/test-state-durability.sh
@@ -46,6 +46,22 @@ assert_contains() {
     esac
 }
 
+# GNU coreutils ships `timeout`; on macOS it arrives as `gtimeout` with
+# coreutils from Homebrew. Without either, the scenarios that bound a run
+# cannot be trusted, so the suite says so and stops.
+TIMEOUT_CMD=""
+for _c in timeout gtimeout; do
+    if command -v "$_c" >/dev/null 2>&1; then
+        TIMEOUT_CMD="$_c"
+        break
+    fi
+done
+if [ -z "$TIMEOUT_CMD" ]; then
+    printf 'ERROR: neither `timeout` nor `gtimeout` is on PATH.\n' >&2
+    printf 'Install GNU coreutils (macOS: `brew install coreutils`) and run again.\n' >&2
+    exit 1
+fi
+
 TEST_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
@@ -112,19 +128,74 @@ orphan_count() {
 rc_of() { printf '%s' "${1%%|*}"; }
 msg_of() { printf '%s' "${1#*|}"; }
 
+# Stubs that make one operation fail on demand. They live in their own
+# directory, put on PATH only by the scenarios that want the failure, and they
+# name the target through an environment variable rather than through file
+# permissions — a permission a superuser ignores would make those scenarios
+# report a break that is not there.
+mkdir -p "$REPO/failbin"
+cat > "$REPO/failbin/mkdir" <<'MKDIRSTUB'
+#!/bin/sh
+for arg in "$@"; do
+    case "$arg" in
+        -*) continue ;;
+    esac
+    case "${MKDIR_FAIL:-}" in
+        "") ;;
+        *)
+            case "$arg" in
+                *"$MKDIR_FAIL"*)
+                    printf 'mkdir: cannot create directory %s: Permission denied\n' \
+                        "$arg" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+    esac
+done
+exec /bin/mkdir "$@"
+MKDIRSTUB
+cat > "$REPO/failbin/mv" <<'MVSTUB'
+#!/bin/sh
+for arg in "$@"; do
+    case "$arg" in
+        -*) continue ;;
+    esac
+    case "${MV_FAIL:-}" in
+        "") ;;
+        *)
+            case "$arg" in
+                *"$MV_FAIL"*)
+                    printf 'mv: cannot move %s: Permission denied\n' "$arg" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+    esac
+done
+exec /bin/mv "$@"
+MVSTUB
+chmod +x "$REPO/failbin/mkdir" "$REPO/failbin/mv"
+
+# What archive_run puts on PATH, and which target each stub refuses. The
+# scenarios that want a failure set these and put them back afterwards.
+RUN_BIN="$REPO/bin"
+MKDIR_FAIL=""
+MV_FAIL=""
+export MKDIR_FAIL MV_FAIL
+
 # Prints "<exit code>|<output on one line>"; `timeout` bounds a run that would
-# otherwise never end. $1, when given, is the state directory to archive.
+# otherwise never end.
 archive_run() {
-    _dir="${1:-$STATE_DIR}"
     _out="$(
-        timeout 10 bash -c '
+        "$TIMEOUT_CMD" 10 bash -c '
             set -uo pipefail
             PATH="$3:$PATH"
             source "$1"
             STATE_DIR="$2"
             CODEX_MAX_ITERATIONS=5
             archive_previous_session
-        ' _ "$COMMON" "$_dir" "$REPO/bin" 2>&1
+        ' _ "$COMMON" "$STATE_DIR" "$RUN_BIN" 2>&1
     )" && _rc=0 || _rc=$?
     printf '%s|%s\n' "$_rc" "$(printf '%s' "$_out" | tr '\n' ' ')"
 }
@@ -132,7 +203,7 @@ archive_run() {
 # Archives $1 once the gate file appears, so two of these claim their directory
 # at the same moment rather than one after the other.
 archive_at_gate() {
-    timeout 10 bash -c '
+    "$TIMEOUT_CMD" 10 bash -c '
         set -uo pipefail
         PATH="$3:$PATH"
         source "$1"
@@ -316,15 +387,17 @@ printf 'Test 6: an archive directory that cannot be created ends the run\n'
 # The archiver only runs when there is something to archive.
 printf 'third session\n' > "$STATE_DIR/last_response.txt"
 
-# A read-only archive root: the timestamped directory cannot be created and
-# does not exist afterwards either, which is the case a loop looking only at
-# `mkdir` failing would take for a name collision and retry forever.
-chmod 555 "$ARCHIVE"
+RUN_BIN="$REPO/failbin:$REPO/bin"
+
+# The timestamped directory cannot be created and does not exist afterwards
+# either, which is the case a loop looking only at `mkdir` failing would take
+# for a name collision and retry forever.
+MKDIR_FAIL="20260904T120000Z"
 r="$(archive_run)"
-chmod 755 "$ARCHIVE"
+MKDIR_FAIL=""
 
 assert_eq "the run ends with an error" "1" "$(rc_of "$r")"
-assert_contains "the error names the directory" "archive" "$(msg_of "$r")"
+assert_contains "the error names the directory" "20260904T120000Z" "$(msg_of "$r")"
 assert_contains "the error says nothing was archived" "Nothing was archived" \
     "$(msg_of "$r")"
 if [ -f "$STATE_DIR/last_response.txt" ]; then
@@ -333,11 +406,12 @@ else
     fail "the artefacts are left where they were" "last_response.txt is gone"
 fi
 
-# A file sitting where the archive root belongs: the root itself cannot be made.
+# The archive root itself cannot be made.
 rm -rf "$ARCHIVE"
-printf 'not a directory\n' > "$ARCHIVE"
+MKDIR_FAIL="/archive"
 r="$(archive_run)"
-rm -f "$ARCHIVE"
+MKDIR_FAIL=""
+RUN_BIN="$REPO/bin"
 
 assert_eq "a blocked archive root also ends the run" "1" "$(rc_of "$r")"
 assert_contains "that error says nothing was archived too" "Nothing was archived" \
@@ -351,12 +425,11 @@ printf 'Test 7: a move into the archive that fails stops the archiver\n'
 rm -rf "$ARCHIVE"
 printf 'fourth session\n' > "$STATE_DIR/last_response.txt"
 
-# Moving a file out of a directory needs write permission on that directory,
-# so a read-only state directory makes every move fail while leaving the
-# artifacts readable.
-chmod 555 "$STATE_DIR"
+RUN_BIN="$REPO/failbin:$REPO/bin"
+MV_FAIL="last_response.txt"
 r="$(archive_run)"
-chmod 755 "$STATE_DIR"
+MV_FAIL=""
+RUN_BIN="$REPO/bin"
 
 assert_eq "the archiver reports the failure" "1" "$(rc_of "$r")"
 assert_contains "the message names the file that stayed" "last_response.txt" \

--- a/plugins/codex-review/test/test-state-durability.sh
+++ b/plugins/codex-review/test/test-state-durability.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+# Regression tests for what survives a write, a reset and a second archiver.
+#
+# Covers four ways the plugin used to lose or invent something it had on disk:
+# a truncating write, a reader chosen by its own answer, a note name reused
+# after a reset, and an archive directory named after a second.
+#
+# Does NOT require the `codex` binary — a stub on PATH plays the reviewer.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROD_SCRIPTS="$SCRIPT_DIR/../skills/codex-review/scripts"
+REVIEW_CMD="$PROD_SCRIPTS/codex-review.sh"
+STATE_CMD="$PROD_SCRIPTS/codex-state.sh"
+COMMON="$PROD_SCRIPTS/common.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+    printf '  PASS: %s\n' "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf '  FAIL: %s\n' "$1"
+    [ -n "${2:-}" ] && printf '    %s\n' "$2"
+    return 0
+}
+
+assert_eq() {
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1" "expected: [$2]; actual: [$3]"
+    fi
+}
+
+assert_contains() {
+    case "$3" in
+        *"$2"*) pass "$1" ;;
+        *) fail "$1" "missing '$2' in: $3" ;;
+    esac
+}
+
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+REPO="$TEST_ROOT/repo"
+mkdir -p "$REPO/bin"
+(
+    cd "$REPO"
+    git init -q -b main
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    git commit -q --allow-empty -m "init"
+)
+
+cat > "$REPO/bin/codex" <<'STUB'
+#!/bin/sh
+out=""
+from_stdin=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        -) from_stdin=1; shift ;;
+        *) shift ;;
+    esac
+done
+if [ -n "$from_stdin" ]; then
+    prompt="$(mktemp)"
+    cat > "$prompt"
+    verdict_file="$(sed -n 's|^After your review, write your verdict to \(.*\)$|\1|p' "$prompt" | head -1)"
+    rm -f "$prompt"
+    [ -n "$verdict_file" ] && printf 'CHANGES_REQUESTED\n' > "$verdict_file"
+fi
+[ -n "$out" ] && printf 'A review.\n' > "$out"
+printf 'session sess_teststub01 ready\n'
+exit 0
+STUB
+chmod +x "$REPO/bin/codex"
+
+(cd "$REPO" && bash "$STATE_CMD" set session_id test-session >/dev/null)
+STATE_DIR="$REPO/.codex-review/main"
+printf 'What changed: nothing much.\n' > "$REPO/desc.md"
+
+run_review() {
+    (
+        unset CODEX_REVIEWER CODEX_MODEL CODEX_REASONING_EFFORT \
+              CODEX_MAX_ITERATIONS CODEX_YOLO CODEX_SESSION_ID AUTO_REVIEW \
+              CODEX_REVIEWER_PROMPT CODEX_PLAN_GUIDE CODEX_CODE_GUIDE \
+              CODEX_SEVERITY_CALIBRATION
+        cd "$REPO" && PATH="$REPO/bin:$PATH" CODEX_HOME="$REPO/codex-home" \
+            bash "$REVIEW_CMD" code --description-file "$REPO/desc.md" >/dev/null 2>&1
+    ) || true
+}
+
+state_cmd() {
+    (
+        unset CODEX_REVIEWER CODEX_SESSION_ID CODEX_MAX_ITERATIONS
+        cd "$REPO" && bash "$STATE_CMD" "$@" 2>&1
+    )
+}
+
+orphan_count() {
+    find "$STATE_DIR" -maxdepth 1 -name '.state.json.*' | wc -l
+}
+
+# ============================
+# Test 1: a write that cannot finish leaves the old state alone
+# ============================
+printf 'Test 1: a write that dies part way through does not empty state.json\n'
+
+state_cmd set phase code >/dev/null
+BEFORE="$(cat "$STATE_DIR/state.json")"
+
+# common.sh is a bash script, so every call into it runs under bash even though
+# the suite itself is POSIX sh.
+write_state_in() {
+    # $1 = extra shell setup (a ulimit, or nothing), $2 = json to write
+    bash -c '
+        set -uo pipefail
+        eval "$1"
+        source "$2"
+        STATE_DIR="$3"
+        write_state "$4"
+    ' _ "$1" "$COMMON" "$STATE_DIR" "$2" >/dev/null 2>&1
+}
+
+# Positive control: the same call, unrestricted, does change the file — without
+# this the assertion below would pass just as well on a write that never ran.
+write_state_in ':' '{"control": 1}' || true
+if [ "$BEFORE" = "$(cat "$STATE_DIR/state.json" 2>/dev/null || printf '<no state.json>')" ]; then
+    fail "the control write reaches state.json" "the file did not change"
+else
+    pass "the control write reaches state.json"
+fi
+printf '%s\n' "$BEFORE" > "$STATE_DIR/state.json"
+BEFORE="$(cat "$STATE_DIR/state.json")"
+
+# `ulimit -f 0` lets a file be created but not filled: the write dies on the
+# first byte, which is the shape of a full disk.
+write_state_in 'ulimit -f 0' '{"wrecked": true}' || true
+
+assert_eq "state.json is the one that was there" "$BEFORE" \
+    "$(cat "$STATE_DIR/state.json" 2>/dev/null || printf '<no state.json>')"
+
+# ============================
+# Test 2: the next write clears what the killed one left
+# ============================
+printf 'Test 2: a temporary file left by a killed write is cleaned up\n'
+
+state_cmd set phase implementing >/dev/null
+assert_eq "no temporary state files are left behind" "0" "$(orphan_count)"
+assert_eq "the write that followed took effect" "implementing" \
+    "$(state_cmd get phase)"
+
+# A temporary file belonging to a process that is still running is not touched.
+printf 'not mine\n' > "$STATE_DIR/.state.json.$$"
+state_cmd set phase code >/dev/null
+if [ -f "$STATE_DIR/.state.json.$$" ]; then
+    pass "a temporary file of a live process is left alone"
+else
+    fail "a temporary file of a live process is left alone" "it was removed"
+fi
+rm -f "$STATE_DIR/.state.json.$$"
+
+printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/plugins/codex-review/test/test-state-durability.sh
+++ b/plugins/codex-review/test/test-state-durability.sh
@@ -167,5 +167,25 @@ else
 fi
 rm -f "$STATE_DIR/.state.json.$$"
 
+# ============================
+# Test 3: an empty field reads as empty, not as zero
+# ============================
+printf 'Test 3: get answers with what the field holds\n'
+
+state_cmd reset >/dev/null
+assert_eq "an empty string field is empty" "" "$(state_cmd get phase)"
+assert_eq "an empty status field is empty" "" "$(state_cmd get last_review_status)"
+assert_eq "a counter is a number" "0" "$(state_cmd get iteration)"
+
+state_cmd set phase code >/dev/null
+assert_eq "a string field that holds something returns it" "code" "$(state_cmd get phase)"
+
+out="$(state_cmd get bogus_field)" && rc=0 || rc=$?
+assert_eq "an unknown field exits 1" "1" "$rc"
+assert_contains "an unknown field says so" "Unsupported state field: bogus_field" "$out"
+assert_contains "an unknown field lists what can be read" "verdict" "$out"
+
+assert_eq "session_id is still readable" "test-session" "$(state_cmd get session_id)"
+
 printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/plugins/codex-review/test/test-state-durability.sh
+++ b/plugins/codex-review/test/test-state-durability.sh
@@ -343,5 +343,29 @@ assert_eq "a blocked archive root also ends the run" "1" "$(rc_of "$r")"
 assert_contains "that error says nothing was archived too" "Nothing was archived" \
     "$(msg_of "$r")"
 
+# ============================
+# Test 7: an artifact that cannot be moved is reported, not passed over
+# ============================
+printf 'Test 7: a move into the archive that fails stops the archiver\n'
+
+rm -rf "$ARCHIVE"
+printf 'fourth session\n' > "$STATE_DIR/last_response.txt"
+
+# Moving a file out of a directory needs write permission on that directory,
+# so a read-only state directory makes every move fail while leaving the
+# artifacts readable.
+chmod 555 "$STATE_DIR"
+r="$(archive_run)"
+chmod 755 "$STATE_DIR"
+
+assert_eq "the archiver reports the failure" "1" "$(rc_of "$r")"
+assert_contains "the message names the file that stayed" "last_response.txt" \
+    "$(msg_of "$r")"
+if [ -f "$STATE_DIR/last_response.txt" ]; then
+    pass "the artifact is still where it was"
+else
+    fail "the artifact is still where it was" "last_response.txt is gone"
+fi
+
 printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/plugins/codex-review/test/test-state-durability.sh
+++ b/plugins/codex-review/test/test-state-durability.sh
@@ -3,7 +3,8 @@
 #
 # Covers four ways the plugin used to lose or invent something it had on disk:
 # a truncating write, a reader chosen by its own answer, a note name reused
-# after a reset, and an archive directory named after a second.
+# after a reset, and an archive directory named after a second. The last
+# scenario holds the archiver to reporting a directory it cannot make.
 #
 # Does NOT require the `codex` binary — a stub on PATH plays the reviewer.
 
@@ -106,6 +107,40 @@ state_cmd() {
 
 orphan_count() {
     find "$STATE_DIR" -maxdepth 1 -name '.state.json.*' | wc -l
+}
+
+rc_of() { printf '%s' "${1%%|*}"; }
+msg_of() { printf '%s' "${1#*|}"; }
+
+# Prints "<exit code>|<output on one line>"; `timeout` bounds a run that would
+# otherwise never end. $1, when given, is the state directory to archive.
+archive_run() {
+    _dir="${1:-$STATE_DIR}"
+    _out="$(
+        timeout 10 bash -c '
+            set -uo pipefail
+            PATH="$3:$PATH"
+            source "$1"
+            STATE_DIR="$2"
+            CODEX_MAX_ITERATIONS=5
+            archive_previous_session
+        ' _ "$COMMON" "$_dir" "$REPO/bin" 2>&1
+    )" && _rc=0 || _rc=$?
+    printf '%s|%s\n' "$_rc" "$(printf '%s' "$_out" | tr '\n' ' ')"
+}
+
+# Archives $1 once the gate file appears, so two of these claim their directory
+# at the same moment rather than one after the other.
+archive_at_gate() {
+    timeout 10 bash -c '
+        set -uo pipefail
+        PATH="$3:$PATH"
+        source "$1"
+        STATE_DIR="$2"
+        CODEX_MAX_ITERATIONS=5
+        while [ ! -e "$4" ]; do :; done
+        archive_previous_session
+    ' _ "$COMMON" "$1" "$REPO/bin" "$GATE" >/dev/null 2>&1
 }
 
 # ============================
@@ -212,6 +247,101 @@ else
     fail "the new cycle's note takes the next free name" \
         "$(find "$STATE_DIR/notes" -name 'code-review-*' | tr '\n' ' ')"
 fi
+
+# ============================
+# Test 5: two archive runs at once get a directory each
+# ============================
+printf 'Test 5: archives claimed at the same moment do not share a directory\n'
+
+ARCHIVE="$REPO/.codex-review/archive"
+rm -rf "$ARCHIVE"
+
+# The directory is named after the second the archive was made in, so the case
+# under test is two runs inside one second. Waiting for that to happen by itself
+# would make the outcome depend on how fast the machine is; a `date` stub on
+# PATH puts both runs in the same second every time.
+cat > "$REPO/bin/date" <<'DATESTUB'
+#!/bin/sh
+case "$*" in
+    *%Y%m%dT*) printf '20260904T120000Z\n' ;;
+    *) printf '2026-09-04T12:00:00Z\n' ;;
+esac
+DATESTUB
+chmod +x "$REPO/bin/date"
+
+# Two state directories under one review root: they compete for the archive
+# name and nothing else, so neither run depends on what the other moves.
+OTHER_DIR="$REPO/.codex-review/other-branch"
+mkdir -p "$OTHER_DIR/notes"
+printf 'first session\n' > "$STATE_DIR/last_response.txt"
+printf 'second session\n' > "$OTHER_DIR/last_response.txt"
+
+# Both runs park on the gate file, so they reach the claim together; a check
+# followed by a create would hand them the same directory.
+GATE="$REPO/gate"
+rm -f "$GATE"
+archive_at_gate "$STATE_DIR" &
+FIRST_PID=$!
+archive_at_gate "$OTHER_DIR" &
+SECOND_PID=$!
+sleep 1
+: > "$GATE"
+wait "$FIRST_PID" && FIRST_RC=0 || FIRST_RC=$?
+wait "$SECOND_PID" && SECOND_RC=0 || SECOND_RC=$?
+
+assert_eq "the first run succeeded" "0" "$FIRST_RC"
+assert_eq "the second run succeeded" "0" "$SECOND_RC"
+
+DIRS="$(find "$ARCHIVE" -mindepth 1 -maxdepth 1 -type d | wc -l)"
+assert_eq "each archive run got its own directory" "2" "$DIRS"
+
+MIXED=0
+CONTENTS=""
+for d in "$ARCHIVE"/*/; do
+    if [ -f "$d/last_response.txt" ]; then
+        CONTENTS="$CONTENTS $(cat "$d/last_response.txt")"
+    else
+        MIXED=1
+    fi
+done
+assert_eq "each directory holds the session it archived" "0" "$MIXED"
+assert_contains "one directory holds the first session" "first session" "$CONTENTS"
+assert_contains "the other holds the second" "second session" "$CONTENTS"
+
+# ============================
+# Test 6: an archive that cannot be created stops instead of trying forever
+# ============================
+printf 'Test 6: an archive directory that cannot be created ends the run\n'
+
+# The archiver only runs when there is something to archive.
+printf 'third session\n' > "$STATE_DIR/last_response.txt"
+
+# A read-only archive root: the timestamped directory cannot be created and
+# does not exist afterwards either, which is the case a loop looking only at
+# `mkdir` failing would take for a name collision and retry forever.
+chmod 555 "$ARCHIVE"
+r="$(archive_run)"
+chmod 755 "$ARCHIVE"
+
+assert_eq "the run ends with an error" "1" "$(rc_of "$r")"
+assert_contains "the error names the directory" "archive" "$(msg_of "$r")"
+assert_contains "the error says nothing was archived" "Nothing was archived" \
+    "$(msg_of "$r")"
+if [ -f "$STATE_DIR/last_response.txt" ]; then
+    pass "the artefacts are left where they were"
+else
+    fail "the artefacts are left where they were" "last_response.txt is gone"
+fi
+
+# A file sitting where the archive root belongs: the root itself cannot be made.
+rm -rf "$ARCHIVE"
+printf 'not a directory\n' > "$ARCHIVE"
+r="$(archive_run)"
+rm -f "$ARCHIVE"
+
+assert_eq "a blocked archive root also ends the run" "1" "$(rc_of "$r")"
+assert_contains "that error says nothing was archived too" "Nothing was archived" \
+    "$(msg_of "$r")"
 
 printf '\nPASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Four durability defects in the `codex-review` plugin, one commit each, plus a
commit that keeps the new scenarios portable. Every fix was reproduced by a
failing test before it landed.

**1. A half-finished write emptied `state.json`.** It was written with `>`, so a
write that died part way through (full disk, killed process) left an empty or
truncated file and the session was gone. `write_state` now writes a temporary
file beside the target and replaces it with `mv`, which is atomic within one
directory. A temporary file left by a killed write is named `.state.json.<pid>`
and removed by the next write, but only when no process holds that pid.

**2. `codex-state.sh get` answered from its own output.** It ran the number
reader first and fell back to the string reader, so an empty string field
answered `0` and an unknown field answered nothing with exit `0`. The reader is
now picked by which field list holds the name; an unknown field exits `1` and
lists what can be read.

**3. A reset overwrote the notes of the cycle it restarted.** `reset` puts the
iteration counter back to `0`, so the next round wrote
`notes/<phase>-review-1.md` over the note already there. `save_note` now steps
over taken names: `<base>.md`, then `<base>.2.md`, `<base>.3.md`.

**4. Two archive runs in one second shared a directory.** The directory is named
after the second it was made in, so two sessions archived inside one second
mixed their logs and notes. The name is now claimed with `mkdir` without `-p` —
the failure is the claim — and the run that loses takes the next numeric suffix.
Only an existing directory sends the loop on; a read-only or full filesystem
ends the archiver with an error instead of spinning through suffixes forever.

**5. An artifact the archiver could not move passed for success.** The moves
ended in `|| true`, which covered a pattern matching nothing and a move that
actually failed alike, leaving a file under a name the next session reuses. They
now go through a helper that skips what does not exist and returns the failure
of what it could not move, naming the file.

New suite `test/test-state-durability.sh` (31 assertions, 7 scenarios) covers all
five. Scenario 5 releases two archivers from a gate file so they claim their
directory at the same moment; scenarios 6 and 7 get their failures from `mkdir`
and `mv` stubs rather than file permissions, so the result does not depend on
who runs the suite. All eleven suites are green. Plugin version 1.4.5 -> 1.4.6.

Stacks on #138 and #140 — merge those first.
