### PR TITLE
fix(zoomkit): показывать тело ошибок API

### DIFF
--- a/plugins/zoomkit/skills/zoomkit/scripts/tests/test_cli.sh
+++ b/plugins/zoomkit/skills/zoomkit/scripts/tests/test_cli.sh
@@ -544,4 +544,14 @@ MOCK_STATUS=429 MOCK_RATE_RESET=1800000000 ZOOMKIT_API_TOKEN="test-token" run_zo
 assert_contains "$TEST_TMP/out" "HTTP 429"
 assert_contains "$TEST_TMP/out" "1800000000"
 
+# Тело ошибки сервиса остаётся видимым для диагностики.
+printf '%s\n' '{"message":"Server Error"}' > "$TEST_TMP/server-error.json"
+if MOCK_STATUS=500 MOCK_BODY_FILE="$TEST_TMP/server-error.json" ZOOMKIT_API_TOKEN="test-token" \
+    run_zoomkit balance > "$TEST_TMP/stdout" 2> "$TEST_TMP/stderr"; then
+    fail "HTTP 500 завершился успешно"
+fi
+[ ! -s "$TEST_TMP/stdout" ] || fail "тело HTTP 500 попало в стандартный вывод"
+assert_contains "$TEST_TMP/stderr" "HTTP 500"
+assert_contains "$TEST_TMP/stderr" '{"message":"Server Error"}'
+
 printf '%s\n' "PASS"

--- a/plugins/zoomkit/skills/zoomkit/scripts/zoomkit.sh
+++ b/plugins/zoomkit/skills/zoomkit/scripts/zoomkit.sh
@@ -382,7 +382,7 @@ body_checksum() {
 print_error_excerpt() {
     [ -s "$BODY_TMP" ] || return 0
     printf '%s\n' "Ответ сервиса (не более 2000 байт):" >&2
-    dd if="$BODY_TMP" bs=2000 count=1 2>/dev/null >&2 || true
+    dd if="$BODY_TMP" bs=2000 count=1 >&2 2>/dev/null || true
     printf '\n' >&2
 }
 


### PR DESCRIPTION
## Что изменено

- исправлен порядок перенаправлений в print_error_excerpt;
- тело ответа ZoomKit теперь выводится в поток ошибок;
- добавлена проверка для HTTP 500, закрепляющая код возврата, поток вывода и сообщение сервера.

## Проверка

- sh plugins/zoomkit/skills/zoomkit/scripts/tests/run.sh
- sh -n для сценария и автономных тестов
- git diff --check